### PR TITLE
create snackbar for toastr messages

### DIFF
--- a/src/app/shared/service/snackbar/snackbar.service.spec.ts
+++ b/src/app/shared/service/snackbar/snackbar.service.spec.ts
@@ -31,7 +31,7 @@ describe('SnackbarService', () => {
       SnackbarComponent,
       expect.objectContaining({
         data: { title: 'Success Title', message: 'Success Message' },
-        panelClass: expect.arrayContaining(['styled-snackbar', 'success-snackbar']),
+        panelClass: expect.arrayContaining(['styled-snackbar', 'success']),
       }),
     );
   });
@@ -42,7 +42,7 @@ describe('SnackbarService', () => {
       SnackbarComponent,
       expect.objectContaining({
         data: { title: 'Error Title', message: 'Error Message' },
-        panelClass: expect.arrayContaining(['styled-snackbar', 'error-snackbar']),
+        panelClass: expect.arrayContaining(['styled-snackbar', 'error']),
       }),
     );
   });
@@ -53,7 +53,7 @@ describe('SnackbarService', () => {
       SnackbarComponent,
       expect.objectContaining({
         data: { title: 'Warning Title', message: 'Warning Message' },
-        panelClass: expect.arrayContaining(['styled-snackbar', 'warning-snackbar']),
+        panelClass: expect.arrayContaining(['styled-snackbar', 'warning']),
       }),
     );
   });
@@ -64,7 +64,7 @@ describe('SnackbarService', () => {
       SnackbarComponent,
       expect.objectContaining({
         data: { title: 'Info Title', message: 'Info Message' },
-        panelClass: expect.arrayContaining(['styled-snackbar', 'info-snackbar']),
+        panelClass: expect.arrayContaining(['styled-snackbar', 'info']),
       }),
     );
   });
@@ -80,9 +80,12 @@ describe('SnackbarService', () => {
     );
   });
 
-  it('should dismiss snackbar', () => {
+  it('should dismiss snackbar after 5 seconds', () => {
+    jest.useFakeTimers();
     service.dismiss();
+    jest.advanceTimersByTime(5000);
     expect(matSnackBarMock.dismiss).toHaveBeenCalled();
+    jest.useRealTimers();
   });
 });
 
@@ -118,10 +121,11 @@ describe('SnackbarComponent', () => {
   });
 
   it('should render title and message', () => {
-    const title = el.query(By.css('.font-semibold')).nativeElement.textContent;
-    const message = el.query(By.css('.text-sm.text-gray-700')).nativeElement.textContent;
-    expect(title).toContain(defaultData.title);
-    expect(message).toContain(defaultData.message);
+    const titleEl = el.query(By.css('.font-bold.text-base'));
+    const messageEls = el.queryAll(By.css('.text-base'));
+
+    expect(titleEl.nativeElement.textContent).toContain(defaultData.title);
+    expect(messageEls[1].nativeElement.textContent).toContain(defaultData.message);
   });
 
   it('should only render title if message is missing', () => {

--- a/src/app/shared/service/snackbar/snackbar.service.spec.ts
+++ b/src/app/shared/service/snackbar/snackbar.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { MatSnackBar, MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
+import { MatSnackBar, MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material/snack-bar';
 import { SnackbarService, SnackbarComponent } from './snackbar.service';
-import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 
 describe('SnackbarService', () => {
   let service: SnackbarService;
@@ -11,7 +12,6 @@ describe('SnackbarService', () => {
   beforeEach(() => {
     matSnackBarMock = {
       openFromComponent: jest.fn(),
-      dismiss: jest.fn(),
     } as unknown as jest.Mocked<MatSnackBar>;
 
     TestBed.configureTestingModule({
@@ -25,106 +25,195 @@ describe('SnackbarService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should show success snackbar', () => {
+  it('should show success snackbar with correct type', () => {
     service.showSuccess('Success Title', 'Success Message');
     expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
       SnackbarComponent,
       expect.objectContaining({
-        data: { title: 'Success Title', message: 'Success Message' },
+        data: {
+          title: 'Success Title',
+          message: 'Success Message',
+          type: 'success',
+        },
         panelClass: expect.arrayContaining(['styled-snackbar', 'success']),
       }),
     );
   });
 
-  it('should show error snackbar', () => {
+  it('should show error snackbar with correct type', () => {
     service.showError('Error Title', 'Error Message');
     expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
       SnackbarComponent,
       expect.objectContaining({
-        data: { title: 'Error Title', message: 'Error Message' },
+        data: {
+          title: 'Error Title',
+          message: 'Error Message',
+          type: 'error',
+        },
         panelClass: expect.arrayContaining(['styled-snackbar', 'error']),
       }),
     );
   });
 
-  it('should show warning snackbar', () => {
+  it('should show warning snackbar with correct type', () => {
     service.showWarning('Warning Title', 'Warning Message');
     expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
       SnackbarComponent,
       expect.objectContaining({
-        data: { title: 'Warning Title', message: 'Warning Message' },
+        data: {
+          title: 'Warning Title',
+          message: 'Warning Message',
+          type: 'warning',
+        },
         panelClass: expect.arrayContaining(['styled-snackbar', 'warning']),
       }),
     );
   });
-
-  it('should show info snackbar', () => {
+  it('should show info snackbar with correct type', () => {
     service.showInfo('Info Title', 'Info Message');
     expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
       SnackbarComponent,
       expect.objectContaining({
-        data: { title: 'Info Title', message: 'Info Message' },
+        data: {
+          title: 'Info Title',
+          message: 'Info Message',
+          type: 'info',
+        },
         panelClass: expect.arrayContaining(['styled-snackbar', 'info']),
       }),
     );
   });
 
-  it('should show snackbar without message and default class', () => {
-    service['openSnackbar']('Title Only');
+  it('should show success snackbar without message', () => {
+    service.showSuccess('Title Only');
     expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
       SnackbarComponent,
       expect.objectContaining({
-        data: { title: 'Title Only', message: undefined },
-        panelClass: ['styled-snackbar'],
+        data: {
+          title: 'Title Only',
+          message: undefined,
+          type: 'success',
+        },
+        panelClass: expect.arrayContaining(['styled-snackbar', 'success']),
+      }),
+    );
+  });
+
+  it('should merge default panel class with custom ones', () => {
+    service.openSnackbar('Title', 'Message', 'success', ['custom-class', 'another-class']);
+
+    expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
+      SnackbarComponent,
+      expect.objectContaining({
+        panelClass: expect.arrayContaining(['styled-snackbar', 'custom-class', 'another-class']),
+        data: {
+          title: 'Title',
+          message: 'Message',
+          type: 'success',
+        },
+      }),
+    );
+  });
+  it('should handle undefined panelClass', () => {
+    service.openSnackbar('Title', 'Message', 'info', undefined);
+
+    expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
+      SnackbarComponent,
+      expect.objectContaining({
+        data: {
+          title: 'Title',
+          message: 'Message',
+          type: 'info',
+        },
+        panelClass: expect.arrayContaining(['styled-snackbar']),
       }),
     );
   });
 });
 
 describe('SnackbarComponent', () => {
-  let fixture: ComponentFixture<SnackbarComponent>;
   let component: SnackbarComponent;
-  let el: DebugElement;
-
-  const defaultData = {
-    title: 'Test Title',
-    message: 'Test Message',
-  };
+  let fixture: ComponentFixture<SnackbarComponent>;
+  let snackBarRefMock: jest.Mocked<MatSnackBarRef<SnackbarComponent>>;
 
   beforeEach(async () => {
+    snackBarRefMock = {
+      dismiss: jest.fn(),
+    } as unknown as jest.Mocked<MatSnackBarRef<SnackbarComponent>>;
+
     await TestBed.configureTestingModule({
-      imports: [SnackbarComponent],
+      imports: [CommonModule, MatIconModule, SnackbarComponent],
       providers: [
         {
           provide: MAT_SNACK_BAR_DATA,
-          useValue: defaultData,
+          useValue: { title: 'Test Title', message: 'Test Message', type: 'success' },
         },
+        { provide: MatSnackBarRef, useValue: snackBarRefMock },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SnackbarComponent);
     component = fixture.componentInstance;
-    el = fixture.debugElement;
     fixture.detectChanges();
   });
 
-  it('should create component', () => {
+  it('should create the component', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render title and message', () => {
-    const titleEl = el.query(By.css('.font-bold.text-base'));
-    const messageEls = el.queryAll(By.css('.text-base'));
+  it('should display the title and message', () => {
+    const titleEl = fixture.debugElement.query(By.css('.font-bold')).nativeElement;
+    const messageEl = fixture.debugElement.query(By.css('.break-all')).nativeElement;
 
-    expect(titleEl.nativeElement.textContent).toContain(defaultData.title);
-    expect(messageEls[1].nativeElement.textContent).toContain(defaultData.message);
+    expect(titleEl.textContent).toContain('Test Title');
+    expect(messageEl.textContent).toContain('Test Message');
   });
 
-  it('should only render title if message is missing', () => {
+  it('should not show message div if message is missing', () => {
     component.data.message = '';
     fixture.detectChanges();
 
-    const message = el.query(By.css('.text-sm.text-gray-700'));
-    expect(message).toBeNull();
+    const messageEl = fixture.debugElement.query(By.css('.wrap-break-word'));
+    expect(messageEl).toBeNull();
+  });
+
+  it('should return the correct icon based on type', () => {
+    component.data.type = 'success';
+    expect(component.getIcon()).toBe('check_circle');
+
+    component.data.type = 'error';
+    expect(component.getIcon()).toBe('error');
+
+    component.data.type = 'warning';
+    expect(component.getIcon()).toBe('warning');
+
+    component.data.type = 'info';
+    expect(component.getIcon()).toBe('info');
+
+    component.data.type = 'unknown';
+    expect(component.getIcon()).toBe('info');
+  });
+
+  it('should default to info icon when type is undefined', () => {
+    component.data.type = undefined as any;
+    expect(component.getIcon()).toBe('info');
+  });
+
+  it('should handle missing title', () => {
+    component.data.title = '';
+    fixture.detectChanges();
+    const titleEl = fixture.debugElement.query(By.css('.font-bold')).nativeElement;
+    expect(titleEl.textContent).toBe('');
+  });
+
+  it('should dismiss the snackbar when close() is called', () => {
+    component.close();
+    expect(snackBarRefMock.dismiss).toHaveBeenCalled();
+  });
+
+  it('should call close() when close button is clicked', () => {
+    const closeBtn = fixture.debugElement.query(By.css('button')).nativeElement;
+    closeBtn.click();
+    expect(snackBarRefMock.dismiss).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/service/snackbar/snackbar.service.spec.ts
+++ b/src/app/shared/service/snackbar/snackbar.service.spec.ts
@@ -1,0 +1,134 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { MatSnackBar, MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
+import { SnackbarService, SnackbarComponent } from './snackbar.service';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+
+describe('SnackbarService', () => {
+  let service: SnackbarService;
+  let matSnackBarMock: jest.Mocked<MatSnackBar>;
+
+  beforeEach(() => {
+    matSnackBarMock = {
+      openFromComponent: jest.fn(),
+      dismiss: jest.fn(),
+    } as unknown as jest.Mocked<MatSnackBar>;
+
+    TestBed.configureTestingModule({
+      providers: [SnackbarService, { provide: MatSnackBar, useValue: matSnackBarMock }],
+    });
+
+    service = TestBed.inject(SnackbarService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should show success snackbar', () => {
+    service.showSuccess('Success Title', 'Success Message');
+    expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
+      SnackbarComponent,
+      expect.objectContaining({
+        data: { title: 'Success Title', message: 'Success Message' },
+        panelClass: expect.arrayContaining(['styled-snackbar', 'success-snackbar']),
+      }),
+    );
+  });
+
+  it('should show error snackbar', () => {
+    service.showError('Error Title', 'Error Message');
+    expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
+      SnackbarComponent,
+      expect.objectContaining({
+        data: { title: 'Error Title', message: 'Error Message' },
+        panelClass: expect.arrayContaining(['styled-snackbar', 'error-snackbar']),
+      }),
+    );
+  });
+
+  it('should show warning snackbar', () => {
+    service.showWarning('Warning Title', 'Warning Message');
+    expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
+      SnackbarComponent,
+      expect.objectContaining({
+        data: { title: 'Warning Title', message: 'Warning Message' },
+        panelClass: expect.arrayContaining(['styled-snackbar', 'warning-snackbar']),
+      }),
+    );
+  });
+
+  it('should show info snackbar', () => {
+    service.showInfo('Info Title', 'Info Message');
+    expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
+      SnackbarComponent,
+      expect.objectContaining({
+        data: { title: 'Info Title', message: 'Info Message' },
+        panelClass: expect.arrayContaining(['styled-snackbar', 'info-snackbar']),
+      }),
+    );
+  });
+
+  it('should show snackbar without message and default class', () => {
+    service['openSnackbar']('Title Only');
+    expect(matSnackBarMock.openFromComponent).toHaveBeenCalledWith(
+      SnackbarComponent,
+      expect.objectContaining({
+        data: { title: 'Title Only', message: undefined },
+        panelClass: ['styled-snackbar'],
+      }),
+    );
+  });
+
+  it('should dismiss snackbar', () => {
+    service.dismiss();
+    expect(matSnackBarMock.dismiss).toHaveBeenCalled();
+  });
+});
+
+describe('SnackbarComponent', () => {
+  let fixture: ComponentFixture<SnackbarComponent>;
+  let component: SnackbarComponent;
+  let el: DebugElement;
+
+  const defaultData = {
+    title: 'Test Title',
+    message: 'Test Message',
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SnackbarComponent],
+      providers: [
+        {
+          provide: MAT_SNACK_BAR_DATA,
+          useValue: defaultData,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SnackbarComponent);
+    component = fixture.componentInstance;
+    el = fixture.debugElement;
+    fixture.detectChanges();
+  });
+
+  it('should create component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render title and message', () => {
+    const title = el.query(By.css('.font-semibold')).nativeElement.textContent;
+    const message = el.query(By.css('.text-sm.text-gray-700')).nativeElement.textContent;
+    expect(title).toContain(defaultData.title);
+    expect(message).toContain(defaultData.message);
+  });
+
+  it('should only render title if message is missing', () => {
+    component.data.message = '';
+    fixture.detectChanges();
+
+    const message = el.query(By.css('.text-sm.text-gray-700'));
+    expect(message).toBeNull();
+  });
+});

--- a/src/app/shared/service/snackbar/snackbar.service.ts
+++ b/src/app/shared/service/snackbar/snackbar.service.ts
@@ -1,0 +1,66 @@
+import { CommonModule } from '@angular/common';
+import { Component, Inject, Injectable } from '@angular/core';
+import { MatSnackBar, MatSnackBarConfig, MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
+import {
+  SNACKBAR_DURATION,
+  SNACKBAR_HORIZONTAL_POSITION,
+  SNACKBAR_VERTICAL_POSITION,
+} from '../../../utils/constants';
+
+@Component({
+  selector: 'app-snackbar',
+  imports: [CommonModule],
+  template: `
+    <div class="flex flex-col whitespace-pre-line">
+      <div>
+        <span class="font-semibold text-sm mb-1 block">{{ data.title }}</span>
+        <span *ngIf="data.message" class="text-sm text-gray-700">{{ data.message }}</span>
+      </div>
+    </div>
+  `,
+})
+export class SnackbarComponent {
+  constructor(@Inject(MAT_SNACK_BAR_DATA) public data: { title: string; message?: string }) {}
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SnackbarService {
+  constructor(private readonly snackBar: MatSnackBar) {}
+
+  private readonly defaultConfig: MatSnackBarConfig = {
+    duration: SNACKBAR_DURATION,
+    horizontalPosition: SNACKBAR_HORIZONTAL_POSITION,
+    verticalPosition: SNACKBAR_VERTICAL_POSITION,
+    panelClass: ['styled-snackbar'],
+  };
+
+  showSuccess(title: string, message?: string) {
+    this.openSnackbar(title, message, ['success-snackbar']);
+  }
+
+  showError(title: string, message?: string) {
+    this.openSnackbar(title, message, ['error-snackbar']);
+  }
+
+  showWarning(title: string, message?: string) {
+    this.openSnackbar(title, message, ['warning-snackbar']);
+  }
+
+  showInfo(title: string, message?: string) {
+    this.openSnackbar(title, message, ['info-snackbar']);
+  }
+
+  private openSnackbar(title: string, message?: string, panelClass: string[] = []) {
+    this.snackBar.openFromComponent(SnackbarComponent, {
+      ...this.defaultConfig,
+      data: { title, message },
+      panelClass: [...this.defaultConfig.panelClass!, ...panelClass],
+    });
+  }
+
+  dismiss() {
+    this.snackBar.dismiss();
+  }
+}

--- a/src/app/shared/service/snackbar/snackbar.service.ts
+++ b/src/app/shared/service/snackbar/snackbar.service.ts
@@ -1,33 +1,73 @@
 import { CommonModule } from '@angular/common';
-import { Component, Inject, Injectable } from '@angular/core';
+import { Component, inject, Inject, Injectable } from '@angular/core';
 import { MatSnackBar, MatSnackBarConfig, MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
+import { MatSnackBarRef } from '@angular/material/snack-bar';
 import {
   SNACKBAR_DURATION,
   SNACKBAR_HORIZONTAL_POSITION,
   SNACKBAR_VERTICAL_POSITION,
 } from '../../../utils/constants';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
   selector: 'app-snackbar',
-  imports: [CommonModule],
+  imports: [CommonModule, MatIcon],
   template: `
-    <div class="flex flex-col whitespace-pre-line">
-      <div>
-        <span class="font-bold text-base mb-1 block">{{ data.title }}</span>
-        <span *ngIf="data.message" class="text-base">{{ data.message }}</span>
+    <div class="flex items-center justify-between gap-4">
+      <div class="flex text-base gap-3 max-w-sm items-center">
+        <mat-icon fontSet="material-icons" class="icon-btn">{{ getIcon() }}</mat-icon>
+        <div class="flex flex-col gap-1">
+          <div class="font-bold text-base mb-1 block">{{ data.title }}</div>
+          <div *ngIf="data.message" class="text-base break-all">{{ data.message }}</div>
+        </div>
       </div>
+
+      <button mat-icon-button (click)="close()" aria-label="Close" class="cursor-pointer">
+        <mat-icon fontSet="material-icons" class="text-xs close-btn font-bold">close</mat-icon>
+      </button>
     </div>
   `,
+  styles: [
+    `
+      .icon-btn {
+        font-size: 35px !important;
+        width: 40px !important;
+        height: auto !important;
+      }
+    `,
+  ],
 })
 export class SnackbarComponent {
-  constructor(@Inject(MAT_SNACK_BAR_DATA) public data: { title: string; message?: string }) {}
+  constructor(
+    @Inject(MAT_SNACK_BAR_DATA) public data: { title: string; type: string; message?: string },
+    private readonly snackBarRef: MatSnackBarRef<SnackbarComponent>,
+  ) {}
+
+  getIcon(): string {
+    switch (this.data.type) {
+      case 'success':
+        return 'check_circle';
+      case 'error':
+        return 'error';
+      case 'warning':
+        return 'warning';
+      case 'info':
+        return 'info';
+      default:
+        return 'info';
+    }
+  }
+
+  close() {
+    this.snackBarRef.dismiss();
+  }
 }
 
 @Injectable({
   providedIn: 'root',
 })
 export class SnackbarService {
-  constructor(private readonly snackBar: MatSnackBar) {}
+  private readonly snackBar = inject(MatSnackBar);
 
   private readonly defaultConfig: MatSnackBarConfig = {
     duration: SNACKBAR_DURATION,
@@ -37,25 +77,30 @@ export class SnackbarService {
   };
 
   showSuccess(title: string, message?: string) {
-    this.openSnackbar(title, message, ['success']);
+    this.openSnackbar(title, message, 'success', ['success']);
   }
 
   showError(title: string, message?: string) {
-    this.openSnackbar(title, message, ['error']);
+    this.openSnackbar(title, message, 'error', ['error']);
   }
 
   showWarning(title: string, message?: string) {
-    this.openSnackbar(title, message, ['warning']);
+    this.openSnackbar(title, message, 'warning', ['warning']);
   }
 
   showInfo(title: string, message?: string) {
-    this.openSnackbar(title, message, ['info']);
+    this.openSnackbar(title, message, 'info', ['info']);
   }
 
-  private openSnackbar(title: string, message?: string, panelClass: string[] = []) {
+  public openSnackbar(
+    title: string,
+    message?: string,
+    type: string = 'info',
+    panelClass: string[] = [],
+  ) {
     this.snackBar.openFromComponent(SnackbarComponent, {
       ...this.defaultConfig,
-      data: { title, message },
+      data: { title, message, type },
       panelClass: [...this.defaultConfig.panelClass!, ...panelClass],
     });
   }

--- a/src/app/shared/service/snackbar/snackbar.service.ts
+++ b/src/app/shared/service/snackbar/snackbar.service.ts
@@ -13,8 +13,8 @@ import {
   template: `
     <div class="flex flex-col whitespace-pre-line">
       <div>
-        <span class="font-semibold text-sm mb-1 block">{{ data.title }}</span>
-        <span *ngIf="data.message" class="text-sm text-gray-700">{{ data.message }}</span>
+        <span class="font-bold text-base mb-1 block">{{ data.title }}</span>
+        <span *ngIf="data.message" class="text-base">{{ data.message }}</span>
       </div>
     </div>
   `,
@@ -37,19 +37,19 @@ export class SnackbarService {
   };
 
   showSuccess(title: string, message?: string) {
-    this.openSnackbar(title, message, ['success-snackbar']);
+    this.openSnackbar(title, message, ['success']);
   }
 
   showError(title: string, message?: string) {
-    this.openSnackbar(title, message, ['error-snackbar']);
+    this.openSnackbar(title, message, ['error']);
   }
 
   showWarning(title: string, message?: string) {
-    this.openSnackbar(title, message, ['warning-snackbar']);
+    this.openSnackbar(title, message, ['warning']);
   }
 
   showInfo(title: string, message?: string) {
-    this.openSnackbar(title, message, ['info-snackbar']);
+    this.openSnackbar(title, message, ['info']);
   }
 
   private openSnackbar(title: string, message?: string, panelClass: string[] = []) {

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -1,6 +1,14 @@
+import {
+  MatSnackBarHorizontalPosition,
+  MatSnackBarVerticalPosition,
+} from '@angular/material/snack-bar';
 import { Navigations } from '../shared/enums/navigation';
 import { TagInputConfig } from '../shared/interfaces/tag-component.interface';
 import { TagColor, TagType } from './types/tag-component.type';
+
+export const SNACKBAR_DURATION = 5000;
+export const SNACKBAR_HORIZONTAL_POSITION: MatSnackBarHorizontalPosition = 'end';
+export const SNACKBAR_VERTICAL_POSITION: MatSnackBarVerticalPosition = 'bottom';
 
 export const AppColors = {
   adminBackgroundColor: 'linear-gradient(to right, #fff4f2, #fffaf6)',

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -1,14 +1,10 @@
-import {
-  MatSnackBarHorizontalPosition,
-  MatSnackBarVerticalPosition,
-} from '@angular/material/snack-bar';
 import { Navigations } from '../shared/enums/navigation';
 import { TagInputConfig } from '../shared/interfaces/tag-component.interface';
 import { TagColor, TagType } from './types/tag-component.type';
 
 export const SNACKBAR_DURATION = 5000;
-export const SNACKBAR_HORIZONTAL_POSITION: MatSnackBarHorizontalPosition = 'end';
-export const SNACKBAR_VERTICAL_POSITION: MatSnackBarVerticalPosition = 'bottom';
+export const SNACKBAR_HORIZONTAL_POSITION = 'end';
+export const SNACKBAR_VERTICAL_POSITION = 'bottom';
 
 export const AppColors = {
   adminBackgroundColor: 'linear-gradient(to right, #fff4f2, #fffaf6)',

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -1,14 +1,10 @@
-import {
-  MatSnackBarHorizontalPosition,
-  MatSnackBarVerticalPosition,
-} from '@angular/material/snack-bar';
 import { Navigations } from '../shared/enums/navigation';
 import { TagInputConfig } from '../shared/interfaces/tag-component.interface';
 import { TagColor, TagType } from './types/tag-component.type';
 
-export const SNACKBAR_DURATION = 5000;
-export const SNACKBAR_HORIZONTAL_POSITION: MatSnackBarHorizontalPosition = 'end';
-export const SNACKBAR_VERTICAL_POSITION: MatSnackBarVerticalPosition = 'bottom';
+export const SNACKBAR_DURATION = 500000;
+export const SNACKBAR_HORIZONTAL_POSITION = 'end';
+export const SNACKBAR_VERTICAL_POSITION = 'bottom';
 
 export const AppColors = {
   adminBackgroundColor: 'linear-gradient(to right, #fff4f2, #fffaf6)',

--- a/src/assets/scss/utils/_material-overrides.scss
+++ b/src/assets/scss/utils/_material-overrides.scss
@@ -127,7 +127,7 @@
   right: 10px !important;
   z-index: 9999;
   animation: slideInFromBottomRight 0.3s ease-out;
-  padding: 0.5rem 0.75rem;
+  padding: 0.4rem 0.2rem;
   border-radius: 5px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
   border: 1px solid #e2e2e2;
@@ -145,6 +145,10 @@
   @media screen and (max-width: 599px) {
     width: calc(100% - 40px);
     max-width: 90%;
+
+    .mat-mdc-snackbar-surface .mdc-snackbar__label {
+      padding: 5px !important;
+    }
   }
 }
 

--- a/src/assets/scss/utils/_material-overrides.scss
+++ b/src/assets/scss/utils/_material-overrides.scss
@@ -119,3 +119,63 @@
     height: 32px !important;
   }
 }
+
+.mat-mdc-snack-bar-container {
+  background-color: white !important;
+  position: fixed !important;
+  bottom: 10px !important;
+  right: 10px !important;
+  z-index: 9999;
+  animation: slideInFromBottomRight 0.3s ease-out;
+  padding: 0.5rem 0.75rem;
+  border-radius: 5px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e2e2e2;
+  --mdc-snackbar-container-shape: 12px;
+  --mdc-snackbar-supporting-text-font:
+    ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+
+  .mat-mdc-snackbar-surface {
+    background-color: white !important;
+    box-shadow: none !important;
+    line-height: 1.4rem !important;
+  }
+
+  @media screen and (max-width: 550px) {
+    width: calc(100% - 40px);
+    max-width: 90%;
+  }
+}
+
+.styled-snackbar {
+  color: #111;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+}
+
+.success-snackbar {
+  --mdc-snackbar-supporting-text-color: #16a34a;
+}
+
+.error-snackbar {
+  --mdc-snackbar-supporting-text-color: #dc2626;
+}
+
+.warning-snackbar {
+  --mdc-snackbar-supporting-text-color: #ca8a04;
+}
+
+.info-snackbar {
+  --mdc-snackbar-supporting-text-color: #2563eb;
+}
+
+@keyframes slideInFromBottomRight {
+  from {
+    transform: translateX(100%) translateY(50%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0) translateY(0);
+    opacity: 1;
+  }
+}

--- a/src/assets/scss/utils/_material-overrides.scss
+++ b/src/assets/scss/utils/_material-overrides.scss
@@ -131,42 +131,48 @@
   border-radius: 5px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
   border: 1px solid #e2e2e2;
+
   --mdc-snackbar-container-shape: 12px;
   --mdc-snackbar-supporting-text-font:
     ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 
   .mat-mdc-snackbar-surface {
-    background-color: white !important;
+    background-color: inherit !important;
     box-shadow: none !important;
     line-height: 1.4rem !important;
   }
 
-  @media screen and (max-width: 550px) {
+  @media screen and (max-width: 599px) {
     width: calc(100% - 40px);
     max-width: 90%;
   }
 }
 
 .styled-snackbar {
-  color: #111;
   font-family: system-ui, sans-serif;
-  font-size: 14px;
 }
 
-.success-snackbar {
-  --mdc-snackbar-supporting-text-color: #16a34a;
+.success,
+.error,
+.info,
+.warning {
+  --mdc-snackbar-supporting-text-color: white;
 }
 
-.error-snackbar {
-  --mdc-snackbar-supporting-text-color: #dc2626;
+.success {
+  background-color: var(--color-success) !important;
 }
 
-.warning-snackbar {
-  --mdc-snackbar-supporting-text-color: #ca8a04;
+.error {
+  background-color: var(--color-error) !important;
 }
 
-.info-snackbar {
-  --mdc-snackbar-supporting-text-color: #2563eb;
+.warning {
+  background-color: var(--color-warn) !important;
+}
+
+.info {
+  background-color: var(--color-info) !important;
 }
 
 @keyframes slideInFromBottomRight {

--- a/src/assets/scss/utils/_variable.scss
+++ b/src/assets/scss/utils/_variable.scss
@@ -10,11 +10,11 @@
   --blue-color: #1e3a8a;
   --red-color: #b91c1c;
 
-  // for snackbar messages
-  --color-error: #e60000;
-  --color-success: #45af52;
-  --color-warn: #ebc21f;
-  --color-info: #54c7ec;
+  // for snackbar messages background
+  --color-error: #e74d3c;
+  --color-success: #07bc0c;
+  --color-warn: #f1c40f;
+  --color-info: #3498db;
 
   --light-green-color: #dcfce7;
   --light-brown-color: #fee2e2;

--- a/src/assets/scss/utils/_variable.scss
+++ b/src/assets/scss/utils/_variable.scss
@@ -10,6 +10,12 @@
   --blue-color: #1e3a8a;
   --red-color: #b91c1c;
 
+  // for snackbar messages
+  --color-error: #e60000;
+  --color-success: #45af52;
+  --color-warn: #ebc21f;
+  --color-info: #54c7ec;
+
   --light-green-color: #dcfce7;
   --light-brown-color: #fee2e2;
   --light-purple-color: #f3e8ff;


### PR DESCRIPTION
Created a snackbar for the toaster messages 

-- jest test 
<img width="1920" height="274" alt="image" src="https://github.com/user-attachments/assets/2cf88a80-9da5-4d0c-bbbb-37fa0ac3ba6e" />
<img width="719" height="261" alt="image" src="https://github.com/user-attachments/assets/0c2782a0-7294-4b5d-8046-894b6e1f5610" />

-- preview
1. success
<img width="383" height="122" alt="image" src="https://github.com/user-attachments/assets/1b8e2bc8-f812-46ed-ad99-a938350797ed" />

2. error
<img width="394" height="153" alt="image" src="https://github.com/user-attachments/assets/72ecd5a2-c7ac-45fc-b210-8d80bb050f6d" />

3. warning
<img width="390" height="132" alt="image" src="https://github.com/user-attachments/assets/8aba98e7-14ff-4d35-b1bb-eac75b2a6dd6" />

4. info
<img width="375" height="130" alt="image" src="https://github.com/user-attachments/assets/03756fbf-d366-4c28-b1db-57c85eadbdb8" />

5. without additional message
<img width="388" height="115" alt="image" src="https://github.com/user-attachments/assets/3a6e70ef-70ee-414f-83c1-f64d70c4b44d" />
