### PR TITLE
register-reset password pages with API call

### DIFF
--- a/src/app/core/auth/components/forgot-password/forgot-password.component.ts
+++ b/src/app/core/auth/components/forgot-password/forgot-password.component.ts
@@ -45,12 +45,13 @@ export class ForgotPasswordComponent {
   private readonly router = inject(Router);
   private readonly validationErrorService = inject(ValidationErrorService);
   private readonly authService = inject(ForgotResetPasswordService);
-  private readonly destroy$ = new Subject<void>();
   private readonly snackbarService = inject(SnackbarService);
 
   forgotPasswordFields = FORGOT_PASSWORD_FORM_FIELDS;
-  forgotPasswordForm: FormGroup;
   sendResetLinkButton = SEND_RESET_LINK_CONFIG;
+  forgotPasswordForm: FormGroup;
+
+  private readonly destroy$ = new Subject<void>();
 
   constructor() {
     // Build reactive form using config field definitions and validators

--- a/src/app/core/auth/components/forgot-password/forgot-password.component.ts
+++ b/src/app/core/auth/components/forgot-password/forgot-password.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
@@ -40,7 +40,7 @@ import { PlatformMessages } from '../../../../utils/constants';
     '../reset-password/reset-password.component.scss',
   ],
 })
-export class ForgotPasswordComponent {
+export class ForgotPasswordComponent implements OnDestroy {
   private readonly fb = inject(FormBuilder);
   private readonly router = inject(Router);
   private readonly validationErrorService = inject(ValidationErrorService);
@@ -111,5 +111,10 @@ export class ForgotPasswordComponent {
           this.snackbarService.showError(`Error`, message);
         },
       });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/core/auth/components/register/register.component.html
+++ b/src/app/core/auth/components/register/register.component.html
@@ -1,36 +1,107 @@
-<!-- Register Form -->
-<form class="custom-form-field" [formGroup]="registerForm" (ngSubmit)="onSubmit()">
-  @for (field of registerFields; track field.name) {
-    <div class="d-flex flex-column justify-content-start form-field pb-1">
-      <mat-label>{{ field.label }}</mat-label>
+<form [formGroup]="isLogin ? userForm : registerForm" (ngSubmit)="onSubmit()">
+  <div class="grid gap-3 pb-3">
+    @for (field of isLogin ? userFields : registerFields; track field.name) {
+      <div class="form-field" [ngClass]="field.gridClass || 'col-span-1 sm:col-span-1'">
+        <mat-label>{{ field.label }}</mat-label>
 
-      <mat-form-field appearance="outline" class="full-width" [floatLabel]="'auto'">
-        <mat-icon fontSet="material-icons-outlined" matPrefix>{{ field.icon || 'input' }}</mat-icon>
+        @if (field.type !== 'file') {
+          <mat-form-field
+            [ngClass]="[
+              field.type === 'textarea' ? 'custom-form-field-text' : 'custom-form-field',
+              'full-width',
+            ]"
+            appearance="outline"
+            floatLabel="auto"
+          >
+            <mat-icon fontSet="material-icons-outlined" matPrefix>{{
+              field.icon || 'person'
+            }}</mat-icon>
 
-        <input
-          #fieldRef
-          matInput
-          [id]="field.name"
-          [type]="field.type"
-          [formControlName]="field.name"
-          [placeholder]="field.placeholder"
-          autocomplete="off"
-          required
-        />
+            @if (field.type === 'textarea') {
+              <textarea
+                matInput
+                [id]="field.name"
+                [formControlName]="field.name"
+                [placeholder]="field.placeholder"
+                rows="3"
+              ></textarea>
+            } @else {
+              <input
+                #fieldRef
+                matInput
+                [id]="field.name"
+                [type]="field.type"
+                [formControlName]="field.name"
+                [placeholder]="field.placeholder"
+                [attr.autocomplete]="'off'"
+                required
+              />
 
-        @if (field.type === 'password') {
-          <button mat-icon-button matSuffix type="button" [appTogglePassword]="fieldRef">
-            <mat-icon fontSet="material-icons-outlined">visibility_off</mat-icon>
-          </button>
+              @if (field.type === 'password') {
+                <mat-icon
+                  fontSet="material-icons-outlined"
+                  [appTogglePassword]="fieldRef"
+                  matSuffix
+                  class="password-toggle-icon"
+                  style="cursor: pointer"
+                  aria-label="Toggle password visibility"
+                >
+                  visibility_off
+                </mat-icon>
+              }
+            }
+
+            <mat-error>
+              {{ getError(field.name) }}
+            </mat-error>
+          </mat-form-field>
         }
 
-        <mat-error>
-          {{ getError(field.name) }}
-        </mat-error>
-      </mat-form-field>
+        @if (field.type === 'file') {
+          <div class="file-input-container mt-3">
+            <input
+              #fileInput
+              [id]="field.name"
+              type="file"
+              class="file-input"
+              (change)="onFileSelected($event)"
+              [accept]="'.jpg,.jpeg,.png'"
+            />
+            <div class="file-upload-row">
+              <app-filled-button
+                [filledButtonConfig]="uploadButton"
+                (buttonClicked)="fileInput.click()"
+                class="custom-upload-button"
+              ></app-filled-button>
+              <span class="selected-file-name"
+                >{{ selectedFile?.name || 'No file chosen' }}
+                <mat-icon *ngIf="selectedFile" (click)="selectedFile = null" class="clear-icon"
+                  >cancel</mat-icon
+                >
+              </span>
+            </div>
+          </div>
+        }
+      </div>
+    }
+  </div>
+
+  @if (isLogin) {
+    <div class="dialog-actions">
+      <app-filled-button
+        [filledButtonConfig]="cancelButton"
+        (buttonClicked)="onCancel()"
+      ></app-filled-button>
+      <app-outline-button
+        [outlineButtonConfig]="isEditMode ? updateUserButton : createUserButton"
+      ></app-outline-button>
+    </div>
+  } @else {
+    <div class="col-span-2 sm:col-span-1">
+      <app-filled-button
+        [filledButtonConfig]="registerButton"
+        class="signup-button w-full mt-4"
+      ></app-filled-button>
     </div>
   }
-
-  <app-filled-button [filledButtonConfig]="registerButton" class="signup-button">
-  </app-filled-button>
 </form>

--- a/src/app/core/auth/components/register/register.component.scss
+++ b/src/app/core/auth/components/register/register.component.scss
@@ -1,21 +1,52 @@
-.signup-button {
-  .loader {
-    border: 2px solid #f3f3f3;
-    border-top: 2px solid var(--global-primary-color);
-    border-radius: 50%;
-    width: 16px;
-    height: 16px;
-    animation: spin 0.8s linear infinite;
-    display: inline-block;
-    margin-right: 0.5rem;
+.password-toggle-icon {
+  padding: 5px 0 0 5px !important;
+}
+
+.file-input-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0 1px;
+
+  .file-input {
+    display: none;
   }
 
-  @keyframes spin {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
+  .file-upload-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem;
+    border: 1px solid #cbd5e0; // light border like native input
+    border-radius: 0.375rem;
+    background-color: #fff;
+    width: 100%;
+
+    &:hover {
+      border-color: var(--global-primary-color);
+      box-shadow: 0 0 0 1px var(--global-primary-color);
     }
   }
+
+  .custom-upload-button {
+    flex-shrink: 0;
+  }
+
+  .selected-file-name {
+    font-size: 0.875rem;
+    color: #9ca3af;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+  }
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e2e8f0;
+  margin-top: 1.5rem;
 }

--- a/src/app/core/auth/components/register/register.component.spec.ts
+++ b/src/app/core/auth/components/register/register.component.spec.ts
@@ -1,72 +1,282 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RegisterComponent } from './register.component';
 import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { ReactiveFormsModule } from '@angular/forms';
 import { ValidationErrorService } from '../../../../shared/service/validation-error/validation-error.service';
-import { RegisterCredentials } from '../../interfaces/register.interface';
+import { RegisterService } from '../../services/register.service';
+import { SnackbarService } from '../../../../shared/service/snackbar/snackbar.service';
+import { PlatformMessages } from '../../../../utils/constants';
 
 describe('RegisterComponent', () => {
   let component: RegisterComponent;
   let fixture: ComponentFixture<RegisterComponent>;
+  let registerService: RegisterService;
+  let snackbarService: SnackbarService;
   let validationErrorService: ValidationErrorService;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [RegisterComponent],
-      providers: [provideRouter([]), ValidationErrorService],
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RegisterComponent, ReactiveFormsModule],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ValidationErrorService,
+          useValue: {
+            getErrorMessage: jest.fn().mockReturnValue('Some error'),
+          },
+        },
+        {
+          provide: RegisterService,
+          useValue: {
+            registerUser: jest.fn(),
+          },
+        },
+        {
+          provide: SnackbarService,
+          useValue: {
+            showSuccess: jest.fn(),
+            showError: jest.fn(),
+          },
+        },
+      ],
     }).compileComponents();
+  }));
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(RegisterComponent);
     component = fixture.componentInstance;
+    registerService = TestBed.inject(RegisterService);
+    snackbarService = TestBed.inject(SnackbarService);
     validationErrorService = TestBed.inject(ValidationErrorService);
     fixture.detectChanges();
   });
 
-  // Component creation
-  it('should create', () => {
+  it('should create component', () => {
     expect(component).toBeTruthy();
   });
 
-  // Invalid form should mark as touched
-  it('should mark form as touched if invalid on submit', () => {
-    const markSpy = jest.spyOn(component.registerForm, 'markAllAsTouched');
+  it('should initialize register form with fields', () => {
+    component.registerFields.forEach((field) => {
+      expect(component.registerForm.contains(field.name)).toBe(true);
+    });
+  });
 
+  it('should return error from getError()', () => {
+    const result = component.getError('fullName');
+    expect(result).toBe('Some error');
+  });
+
+  it('should validate password mismatch', () => {
+    const form = component.registerForm;
+    form.get('password')?.setValue('Pass123!');
+    form.get('confirmPassword')?.setValue('Pass456!');
+
+    component.passwordMatchValidator(form);
+    expect(form.get('confirmPassword')?.hasError('passwordMismatch')).toBe(true);
+  });
+
+  it('should clear mismatch error if passwords match', () => {
+    const form = component.registerForm;
+    form.get('confirmPassword')?.setErrors({ passwordMismatch: true });
+    form.get('password')?.setValue('Pass123!');
+    form.get('confirmPassword')?.setValue('Pass123!');
+
+    component.passwordMatchValidator(form);
+    expect(form.get('confirmPassword')?.errors).toBeNull();
+  });
+
+  it('should validate file type and size correctly', () => {
+    const mockFile = new File([''], 'test.png', { type: 'image/png' });
+    Object.defineProperty(mockFile, 'size', { value: 1024 * 1024 }); // 1MB
+
+    const event = {
+      target: { files: [mockFile] },
+    } as unknown as Event;
+
+    component.onFileSelected(event);
+    expect(component.selectedFile).toBe(mockFile);
+  });
+
+  it('should reject large file (>5MB)', () => {
+    const mockFile = new File([''], 'large.jpg', { type: 'image/jpeg' });
+    Object.defineProperty(mockFile, 'size', { value: 6 * 1024 * 1024 });
+
+    const event = {
+      target: { files: [mockFile] },
+    } as unknown as Event;
+
+    component.onFileSelected(event);
+    expect(component.selectedFile).toBeNull();
+    expect(component.userForm.get('profilePicture')?.hasError('fileSize')).toBe(true);
+  });
+
+  it('should reject invalid file type', () => {
+    const mockFile = new File([''], 'invalid.pdf', { type: 'application/pdf' });
+
+    const event = {
+      target: { files: [mockFile] },
+    } as unknown as Event;
+
+    component.onFileSelected(event);
+    expect(component.selectedFile).toBeNull();
+    expect(component.userForm.get('profilePicture')?.hasError('fileType')).toBe(true);
+  });
+
+  it('should call registerUser and show success snackbar', () => {
+    component.registerForm.setValue({
+      fullName: 'Test User',
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'Password123!',
+      confirmPassword: 'Password123!',
+      bio: '',
+    });
+
+    jest.spyOn(registerService, 'registerUser').mockReturnValue(
+      of({
+        result: true,
+        statusCode: 201,
+        message: 'Registered',
+        data: null,
+      }),
+    );
+
+    const successSpy = jest.spyOn(snackbarService, 'showSuccess');
+
+    component.registerFormSubmit();
+
+    expect(registerService.registerUser).toHaveBeenCalled();
+    expect(successSpy).toHaveBeenCalledWith('Success', 'Registered');
+  });
+
+  it('should handle registration error response', () => {
+    component.registerForm.setValue({
+      fullName: 'Test User',
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'Password123!',
+      confirmPassword: 'Password123!',
+      bio: '',
+    });
+
+    jest.spyOn(registerService, 'registerUser').mockReturnValue(
+      of({
+        result: false,
+        statusCode: 400,
+        message: 'Registration failed',
+        data: null,
+      }),
+    );
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+
+    component.registerFormSubmit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error! 400', 'Registration failed');
+  });
+
+  it('should handle registration HTTP error', () => {
+    component.registerForm.setValue({
+      fullName: 'Test User',
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'Password123!',
+      confirmPassword: 'Password123!',
+      bio: '',
+    });
+
+    jest
+      .spyOn(registerService, 'registerUser')
+      .mockReturnValue(throwError(() => ({ error: { message: 'Server error' } })));
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+
+    component.registerFormSubmit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error', 'Server error');
+  });
+
+  it('should call createUserFormSubmit if isLogin is true', () => {
+    component.isLogin = true;
+    const spy = jest.spyOn(component, 'createUserFormSubmit');
     component.onSubmit();
-
-    expect(markSpy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
   });
 
-  // Form field existence
-  it('should initialize form fields correctly', () => {
-    const controls = component.registerForm.controls;
-    expect(controls['fullName']).toBeDefined();
-    expect(controls['email']).toBeDefined();
-    expect(controls['password']).toBeDefined();
-    expect(controls['username']).toBeDefined();
+  it('should call registerFormSubmit if isLogin is false', () => {
+    component.isLogin = false;
+    const spy = jest.spyOn(component, 'registerFormSubmit');
+    component.onSubmit();
+    expect(spy).toHaveBeenCalled();
+  });
+  it('should handle getError when field is not found', () => {
+    const error = component.getError('nonExistentField');
+    expect(error).toBe('Some error');
   });
 
-  // Config value check
-  it('should display the correct register button label', () => {
-    expect(component.registerButton.label).toBe('Create An Account');
+  it('should return error even if field has no validationMessages', () => {
+    component.registerFields.push({ name: 'noValidation', type: 'text' } as any);
+
+    const error = component.getError('noValidation');
+    expect(error).toBe('Some error');
+    component.registerFields.pop();
   });
 
-  // getError should call validationErrorService with proper args
-  it('should return validation error from getError', () => {
-    const fieldName = 'email';
-    const mockMessage = 'Email is required.';
-    const control = component.registerForm.get(fieldName);
-    control?.markAsTouched();
-    control?.setErrors({ required: true });
-
-    const spy = jest.spyOn(validationErrorService, 'getErrorMessage').mockReturnValue(mockMessage);
-
-    const result = component.getError(fieldName);
-    expect(spy).toHaveBeenCalledWith(control, expect.any(Object), fieldName);
-    expect(result).toBe(mockMessage);
+  it('should return error when field is not found at all', () => {
+    const error = component.getError('notFoundField');
+    expect(error).toBe('Some error');
   });
 
-  // getError should return null if control not found
-  it('should return null if getError called with unknown field', () => {
-    const result = component.getError('nonexistentField');
-    expect(result).toBeNull();
+  it('should treat non-201 with success result as error', () => {
+    component.registerForm.setValue({
+      fullName: 'Test User',
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'Password123!',
+      confirmPassword: 'Password123!',
+      bio: '',
+    });
+
+    jest.spyOn(registerService, 'registerUser').mockReturnValue(
+      of({
+        result: true,
+        statusCode: 200, // non-201
+        message: 'Weird success',
+        data: null,
+      }),
+    );
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+
+    component.registerFormSubmit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error! 200', 'Weird success');
+  });
+
+  it('should fallback to default message when success response has no message', () => {
+    component.registerForm.setValue({
+      fullName: 'Test User',
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'Password123!',
+      confirmPassword: 'Password123!',
+      bio: '',
+    });
+
+    jest.spyOn(registerService, 'registerUser').mockReturnValue(
+      of({
+        result: true,
+        statusCode: 201,
+        message: '', // message missing
+        data: null,
+      }),
+    );
+
+    const successSpy = jest.spyOn(snackbarService, 'showSuccess');
+
+    component.registerFormSubmit();
+
+    expect(successSpy).toHaveBeenCalledWith('Success', PlatformMessages.registerSuccessfully);
   });
 });

--- a/src/app/core/auth/components/register/register.component.spec.ts
+++ b/src/app/core/auth/components/register/register.component.spec.ts
@@ -98,9 +98,9 @@ describe('RegisterComponent', () => {
     expect(component.selectedFile).toBe(mockFile);
   });
 
-  it('should reject large file (>5MB)', () => {
+  it('should reject large file (>10MB)', () => {
     const mockFile = new File([''], 'large.jpg', { type: 'image/jpeg' });
-    Object.defineProperty(mockFile, 'size', { value: 6 * 1024 * 1024 });
+    Object.defineProperty(mockFile, 'size', { value: 11 * 1024 * 1024 });
 
     const event = {
       target: { files: [mockFile] },

--- a/src/app/core/auth/components/register/register.component.ts
+++ b/src/app/core/auth/components/register/register.component.ts
@@ -1,31 +1,45 @@
-import { Component, inject } from '@angular/core';
+import { Component, EventEmitter, inject, Output } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FilledButtonComponent } from '../../../../shared/components/filled-button/filled-button.component';
 import { CommonModule } from '@angular/common';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
+import { MatFormField, MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { RegisterCredentials } from '../../interfaces/register.interface';
 import {
+  CANCEL_BUTTON_CONFIG,
+  CREATE_USER_BUTTON_CONFIG,
   REGISTER_BUTTON_CONFIG,
   REGISTER_FORM_FIELDS,
+  UPDATE_USER_BUTTON_CONFIG,
+  UPLOAD_BUTTON_CONFIG,
+  USER_FORM_FIELDS,
 } from '../../configs/register.component.config';
 import { TogglePasswordDirective } from '../toggle-password.directive';
 import { ValidationErrorService } from '../../../../shared/service/validation-error/validation-error.service';
+import { Router, RouterLink } from '@angular/router';
+import { Subject, takeUntil } from 'rxjs';
+import { SnackbarService } from '../../../../shared/service/snackbar/snackbar.service';
+import { RegisterService } from '../../services/register.service';
+import { PlatformMessages } from '../../../../utils/constants';
+import { RegisterCredential } from '../../interfaces/register.interface';
+import { TextButtonComponent } from '../../../../shared/components/text-button/text-button.component';
+import { OutlineButtonComponent } from '../../../../shared/components/outline-button/outline-button.component';
+import { selectedTabIndexSignal } from '../login-signup/login-signup.component';
 
 @Component({
   selector: 'app-register',
-  standalone: true,
   imports: [
     ReactiveFormsModule,
     FilledButtonComponent,
     CommonModule,
-    MatFormFieldModule,
-    MatInputModule,
     MatIconModule,
     MatProgressSpinnerModule,
     TogglePasswordDirective,
+    MatInputModule,
+    MatFormField,
+    RouterLink,
+    TextButtonComponent,
+    OutlineButtonComponent,
   ],
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.scss', '../login-signup/login-signup.component.scss'],
@@ -33,16 +47,42 @@ import { ValidationErrorService } from '../../../../shared/service/validation-er
 export class RegisterComponent {
   private readonly fb = inject(FormBuilder);
   private readonly validationErrorService = inject(ValidationErrorService);
+  private readonly snackbarService = inject(SnackbarService);
+  private readonly registerService = inject(RegisterService);
 
   registerFields = REGISTER_FORM_FIELDS;
+  userFields = USER_FORM_FIELDS;
   registerButton = REGISTER_BUTTON_CONFIG;
+  uploadButton = UPLOAD_BUTTON_CONFIG;
+  cancelButton = CANCEL_BUTTON_CONFIG;
+  updateUserButton = UPDATE_USER_BUTTON_CONFIG;
+  createUserButton = CREATE_USER_BUTTON_CONFIG;
+
+  isLogin = false;
+  isEditMode = false;
+  selectedFile: File | null = null;
 
   registerForm: FormGroup;
+  userForm: FormGroup;
 
+  private readonly destroy$ = new Subject<void>();
+
+  // Initialize forms with dynamic fields and validators
   constructor() {
-    // Create form group using fields and validators
-    this.registerForm = this.fb.group(
-      this.registerFields.reduce(
+    const formControls = this.registerFields.reduce(
+      (acc, field) => {
+        acc[field.name] = ['', field.validators];
+        return acc;
+      },
+      {} as Record<string, any>,
+    );
+
+    this.registerForm = this.fb.group(formControls, {
+      validators: this.passwordMatchValidator,
+    });
+
+    this.userForm = this.fb.group(
+      this.userFields.reduce(
         (acc, field) => {
           acc[field.name] = ['', field.validators];
           return acc;
@@ -52,25 +92,125 @@ export class RegisterComponent {
     );
   }
 
+  // Get dynamic validation error message for a given field
   getError(fieldName: string): string | null {
-    const control = this.registerForm.get(fieldName);
-    const field = this.registerFields.find((f) => f.name === fieldName);
+    const form = this.isLogin ? this.userForm : this.registerForm;
+    const fieldList = this.isLogin ? this.userFields : this.registerFields;
+
+    const control = form.get(fieldName);
+    const field = fieldList.find((f) => f.name === fieldName);
     const customMessages = field?.validationMessages || {};
 
     return this.validationErrorService.getErrorMessage(control!, customMessages, fieldName);
   }
 
-  // Handle form submission with validation and simulated delay
-  onSubmit(): void {
+  // Custom validator to ensure password and confirmPassword match
+  passwordMatchValidator(formGroup: FormGroup): null {
+    const password = formGroup.get('password')?.value;
+    const confirmPasswordControl = formGroup.get('confirmPassword');
+
+    if (confirmPasswordControl?.value && password !== confirmPasswordControl?.value) {
+      confirmPasswordControl?.setErrors({ passwordMismatch: true });
+    } else {
+      if (confirmPasswordControl?.hasError('passwordMismatch')) {
+        confirmPasswordControl.setErrors(null);
+      }
+    }
+    return null;
+  }
+
+  // Handle profile picture file selection and validation
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const control = this.userForm.get('profilePicture');
+
+    if (input.files && input.files.length > 0) {
+      const file = input.files[0];
+      const allowedTypes = ['image/jpeg', 'image/png'];
+
+      control?.setErrors(null);
+
+      if (file.size > 5 * 1024 * 1024) {
+        control?.setErrors({ fileSize: true });
+        control?.markAsTouched();
+        this.selectedFile = null;
+        return;
+      }
+
+      if (!allowedTypes.includes(file.type)) {
+        control?.setErrors({ fileType: true });
+        control?.markAsTouched();
+        this.selectedFile = null;
+        return;
+      }
+
+      this.selectedFile = file;
+    }
+  }
+
+  // Submit register form and call API to create user
+  registerFormSubmit() {
     if (this.registerForm.invalid) {
       this.registerForm.markAllAsTouched();
       return;
     }
 
-    const credentials: RegisterCredentials = {
+    const credentials: RegisterCredential = {
       fullName: this.registerForm.value.fullName,
+      userName: this.registerForm.value.username,
       email: this.registerForm.value.email,
       password: this.registerForm.value.password,
+      confirmPassword: this.registerForm.value.confirmPassword,
+      bio: this.registerForm.value.bio || '',
     };
+
+    this.registerService
+      .registerUser(credentials)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          if (!res.result || res.statusCode !== 201) {
+            this.snackbarService.showError(
+              `${PlatformMessages.errorTitle} ${res.statusCode}`,
+              res.message || PlatformMessages.errorMessage,
+            );
+            return;
+          }
+
+          this.snackbarService.showSuccess(
+            'Success',
+            res.message || PlatformMessages.registerSuccessfully,
+          );
+
+          // Switch to login tab after successful registration
+          selectedTabIndexSignal.set(0);
+        },
+        error: (err) => {
+          const message = err?.error?.message || PlatformMessages.errorMessage;
+          this.snackbarService.showError('Error', message);
+        },
+      });
   }
+
+  // Submit user form (for user update or create actions)
+  createUserFormSubmit() {
+    if (this.userForm.invalid) {
+      this.userForm.markAllAsTouched();
+      return;
+    }
+
+    // Add submission logic
+  }
+
+  // Determine which form to submit based on tab
+  onSubmit(): void {
+    if (!this.isLogin) {
+      this.registerFormSubmit();
+    } else {
+      this.createUserFormSubmit();
+    }
+  }
+
+  // Handle cancel button click
+  onCancel(): void {}
 }

--- a/src/app/core/auth/components/register/register.component.ts
+++ b/src/app/core/auth/components/register/register.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, inject, Output } from '@angular/core';
+import { Component, inject, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FilledButtonComponent } from '../../../../shared/components/filled-button/filled-button.component';
 import { CommonModule } from '@angular/common';
@@ -16,11 +16,15 @@ import {
 } from '../../configs/register.component.config';
 import { TogglePasswordDirective } from '../toggle-password.directive';
 import { ValidationErrorService } from '../../../../shared/service/validation-error/validation-error.service';
-import { Router, RouterLink } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 import { SnackbarService } from '../../../../shared/service/snackbar/snackbar.service';
 import { RegisterService } from '../../services/register.service';
-import { PlatformMessages } from '../../../../utils/constants';
+import {
+  ALLOWED_IMAGE_TYPES,
+  MAX_FILE_UPLOAD_SIZE,
+  PlatformMessages,
+} from '../../../../utils/constants';
 import { RegisterCredential } from '../../interfaces/register.interface';
 import { TextButtonComponent } from '../../../../shared/components/text-button/text-button.component';
 import { OutlineButtonComponent } from '../../../../shared/components/outline-button/outline-button.component';
@@ -44,7 +48,7 @@ import { selectedTabIndexSignal } from '../login-signup/login-signup.component';
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.scss', '../login-signup/login-signup.component.scss'],
 })
-export class RegisterComponent {
+export class RegisterComponent implements OnDestroy {
   private readonly fb = inject(FormBuilder);
   private readonly validationErrorService = inject(ValidationErrorService);
   private readonly snackbarService = inject(SnackbarService);
@@ -126,11 +130,11 @@ export class RegisterComponent {
 
     if (input.files && input.files.length > 0) {
       const file = input.files[0];
-      const allowedTypes = ['image/jpeg', 'image/png'];
+      const allowedTypes = ALLOWED_IMAGE_TYPES;
 
       control?.setErrors(null);
 
-      if (file.size > 5 * 1024 * 1024) {
+      if (file.size > MAX_FILE_UPLOAD_SIZE) {
         control?.setErrors({ fileSize: true });
         control?.markAsTouched();
         this.selectedFile = null;
@@ -213,4 +217,9 @@ export class RegisterComponent {
 
   // Handle cancel button click
   onCancel(): void {}
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 }

--- a/src/app/core/auth/components/reset-link-send-successfully/reset-link-send-successfully.component.ts
+++ b/src/app/core/auth/components/reset-link-send-successfully/reset-link-send-successfully.component.ts
@@ -17,6 +17,7 @@ import { LoaderService } from '../../../../shared/service/loader/loader.service'
   styleUrls: [
     './reset-link-send-successfully.component.scss',
     '../login-signup/login-signup.component.scss',
+    '../reset-password/reset-password.component.scss',
   ],
 })
 export class ResetLinkSendSuccessfullyComponent {

--- a/src/app/core/auth/components/reset-password/reset-password.component.html
+++ b/src/app/core/auth/components/reset-password/reset-password.component.html
@@ -21,13 +21,17 @@
     </div>
 
     <!-- Reactive form for reset password -->
-    <form class="custom-form-field" [formGroup]="resetForm" (ngSubmit)="onSubmit()">
+    <form [formGroup]="resetForm" (ngSubmit)="onSubmit()">
       <!-- Render each form field dynamically -->
       @for (field of resetFields; track field.name) {
         <div class="d-flex flex-column justify-content-start form-field pb-1">
           <mat-label>{{ field.label }}</mat-label>
 
-          <mat-form-field appearance="outline" class="full-width" [floatLabel]="'auto'">
+          <mat-form-field
+            appearance="outline"
+            class="full-width custom-form-field"
+            [floatLabel]="'auto'"
+          >
             <mat-icon fontSet="material-icons-outlined" matPrefix>{{
               field.icon || 'lock'
             }}</mat-icon>
@@ -44,9 +48,16 @@
             />
 
             @if (field.type === 'password') {
-              <button mat-icon-button matSuffix type="button" [appTogglePassword]="fieldRef">
-                <mat-icon fontSet="material-icons-outlined">visibility_off</mat-icon>
-              </button>
+              <mat-icon
+                fontSet="material-icons-outlined"
+                [appTogglePassword]="fieldRef"
+                matSuffix
+                class="password-toggle-icon"
+                style="cursor: pointer"
+                aria-label="Toggle password visibility"
+              >
+                visibility_off
+              </mat-icon>
             }
 
             <mat-error>

--- a/src/app/core/auth/components/reset-password/reset-password.component.scss
+++ b/src/app/core/auth/components/reset-password/reset-password.component.scss
@@ -4,3 +4,11 @@
     font-weight: 500 !important;
   }
 }
+
+.auth-card {
+  max-width: 29rem !important;
+}
+
+.back-link-container {
+  max-width: 28rem !important;
+}

--- a/src/app/core/auth/components/reset-password/reset-password.component.spec.ts
+++ b/src/app/core/auth/components/reset-password/reset-password.component.spec.ts
@@ -1,24 +1,79 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ResetPasswordComponent } from './reset-password.component';
+import { ReactiveFormsModule } from '@angular/forms';
 import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
 import { ValidationErrorService } from '../../../../shared/service/validation-error/validation-error.service';
-import { FormBuilder } from '@angular/forms';
-import { ResetCredential } from '../../interfaces/forgot-reset-password.interface';
+import { ForgotResetPasswordService } from '../../services/forgot-reset-password.service';
+import { SnackbarService } from '../../../../shared/service/snackbar/snackbar.service';
+import { SEND_RESET_LINK_CONFIG } from '../../configs/reset-password.component.config';
+import { Router, ActivatedRoute } from '@angular/router';
+import { Navigations } from '../../../../shared/enums/navigation';
+import { PlatformMessages } from '../../../../utils/constants';
 
 describe('ResetPasswordComponent', () => {
   let component: ResetPasswordComponent;
   let fixture: ComponentFixture<ResetPasswordComponent>;
   let validationErrorService: ValidationErrorService;
+  let authService: ForgotResetPasswordService;
+  let snackbarService: SnackbarService;
+  let router: Router;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ResetPasswordComponent],
-      providers: [provideRouter([])],
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ResetPasswordComponent, ReactiveFormsModule],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ValidationErrorService,
+          useValue: {
+            getErrorMessage: jest.fn(),
+          },
+        },
+        {
+          provide: ForgotResetPasswordService,
+          useValue: {
+            verifyResetToken: jest.fn().mockReturnValue(
+              of({
+                result: true,
+                statusCode: 200,
+                message: 'Token valid',
+                data: true,
+              }),
+            ),
+            resetPassword: jest.fn(),
+          },
+        },
+        {
+          provide: SnackbarService,
+          useValue: {
+            showSuccess: jest.fn(),
+            showError: jest.fn(),
+          },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap: {
+                get: (key: string) => (key === 'token' ? 'test-reset-token' : null),
+              },
+            },
+          },
+        },
+      ],
     }).compileComponents();
+  }));
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(ResetPasswordComponent);
     component = fixture.componentInstance;
     validationErrorService = TestBed.inject(ValidationErrorService);
+    authService = TestBed.inject(ForgotResetPasswordService);
+    snackbarService = TestBed.inject(SnackbarService);
+    router = TestBed.inject(Router);
+
+    component.ngOnInit();
     fixture.detectChanges();
   });
 
@@ -26,132 +81,316 @@ describe('ResetPasswordComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should initialize form with all controls', () => {
-    const controls = component.resetForm.controls;
-    expect(controls['password']).toBeDefined();
-    expect(controls['confirmPassword']).toBeDefined();
+  it('should initialize form with all reset fields', () => {
+    component.resetFields.forEach((field) => {
+      expect(component.resetForm.contains(field.name)).toBe(true);
+    });
   });
 
-  it('should return correct field name from trackByField()', () => {
-    const result = component.trackByField(0, { name: 'password' });
-    expect(result).toBe('password');
+  it('should read reset token from query params', () => {
+    expect(component.resetToken).toBe('test-reset-token');
   });
 
-  it('should call getError() and return null if control is valid', () => {
-    const control = component.resetForm.get('password');
-    control?.setValue('Password@123');
-    jest.spyOn(validationErrorService, 'getErrorMessage').mockReturnValue(null);
-
-    const result = component.getError('password');
-    expect(result).toBeNull();
-    expect(validationErrorService.getErrorMessage).toHaveBeenCalled();
-  });
-
-  it('should apply password mismatch error when passwords do not match', () => {
-    component.resetForm.get('password')?.setValue('Password@123');
-    component.resetForm.get('confirmPassword')?.setValue('WrongPass');
-
-    const result = component.passwordMatchValidator(component.resetForm);
-    expect(component.resetForm.get('confirmPassword')?.hasError('passwordMismatch')).toBe(true);
-    expect(result).toBeNull();
-  });
-
-  it('should clear passwordMismatch error when passwords match', () => {
-    const control = component.resetForm.get('confirmPassword');
-    control?.setErrors({ passwordMismatch: true });
-
-    component.resetForm.get('password')?.setValue('MatchPass@1');
-    control?.setValue('MatchPass@1');
-
-    component.passwordMatchValidator(component.resetForm);
-
-    expect(control?.hasError('passwordMismatch')).toBe(false);
-  });
-
-  it('should mark all as touched if form is invalid on submit', () => {
+  it('should mark form as touched and return if invalid', () => {
     const markSpy = jest.spyOn(component.resetForm, 'markAllAsTouched');
-
     component.onSubmit();
-
     expect(markSpy).toHaveBeenCalled();
   });
 
-  it('should return null from validator if confirmPassword is missing', () => {
-    component.resetForm.removeControl('confirmPassword');
-
-    const result = component.passwordMatchValidator(component.resetForm);
-
-    expect(result).toBeNull();
-  });
-
-  it('should return null if confirmPassword control is missing', () => {
-    const formGroup = new FormBuilder().group({
-      password: ['Test@123'],
-      // no confirmPassword field
-    });
-
-    const result = component.passwordMatchValidator(formGroup);
-    expect(result).toBeNull();
-  });
-
-  it('should set passwordMismatch error when passwords do not match', () => {
-    const formGroup = new FormBuilder().group({
-      password: ['Password123'],
-      confirmPassword: ['Mismatch123'],
-    });
-
-    const result = component.passwordMatchValidator(formGroup);
-    expect(formGroup.get('confirmPassword')?.hasError('passwordMismatch')).toBe(true);
-    expect(result).toBeNull();
-  });
-
-  it('should not set passwordMismatch error when passwords match', () => {
-    const formGroup = new FormBuilder().group({
-      password: ['SamePassword1'],
-      confirmPassword: ['SamePassword1'],
-    });
-
-    const result = component.passwordMatchValidator(formGroup);
-    expect(formGroup.get('confirmPassword')?.hasError('passwordMismatch')).toBe(false);
-    expect(result).toBeNull();
-  });
-
-  it('should fallback to empty object if validationMessages is undefined', () => {
-    // Patch a field with no validationMessages
-    const mockField = {
-      name: 'password',
-      validators: [],
+  it('should call resetPassword and show success snackbar on valid form', () => {
+    const credentials = {
+      password: 'NewPassword123!',
+      confirmPassword: 'NewPassword123!',
     };
-    component.resetFields = [mockField as any];
+    component.resetForm.setValue(credentials);
 
-    const control = component.resetForm.get('password');
-    control?.setValue('');
+    const resetSpy = jest
+      .spyOn(authService, 'resetPassword')
+      .mockReturnValue(
+        of({ result: true, statusCode: 200, message: 'Password reset successfully', data: null }),
+      );
 
-    jest.spyOn(validationErrorService, 'getErrorMessage').mockReturnValue('Mocked error');
-
-    const result = component.getError('password');
-
-    expect(result).toBe('Mocked error');
-    expect(validationErrorService.getErrorMessage).toHaveBeenCalledWith(control, {}, 'password');
-  });
-
-  it('should create credentials and not mark as touched when form is valid', () => {
-    const password = 'ValidPass@1';
-
-    component.resetForm.get('password')?.setValue(password);
-    component.resetForm.get('confirmPassword')?.setValue(password);
-
-    const markSpy = jest.spyOn(component.resetForm, 'markAllAsTouched');
+    const successSpy = jest.spyOn(snackbarService, 'showSuccess');
+    const navigateSpy = jest.spyOn(router, 'navigate');
 
     component.onSubmit();
 
-    const credentials: ResetCredential = {
-      password,
-      confirmPassword: password,
-    };
+    expect(resetSpy).toHaveBeenCalledWith({
+      password: credentials.password,
+      resetPasswordToken: 'test-reset-token',
+    });
+    expect(successSpy).toHaveBeenCalledWith('Success', 'Password reset successfully');
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.Login]);
+  });
 
-    // Optional: you can spy on a service method here if you use it later
-    expect(component.resetForm.valid).toBe(true);
-    expect(markSpy).not.toHaveBeenCalled();
+  it('should show error snackbar and navigate to forget-password if reset fails (non-200)', () => {
+    const credentials = {
+      password: 'NewPassword123!',
+      confirmPassword: 'NewPassword123!',
+    };
+    component.resetForm.setValue(credentials);
+
+    jest
+      .spyOn(authService, 'resetPassword')
+      .mockReturnValue(
+        of({ result: false, statusCode: 400, message: 'Invalid token', data: null }),
+      );
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.onSubmit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error! 400', 'Invalid token');
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.ForgetPassword]);
+  });
+
+  it('should show error snackbar and navigate to forget-password on HTTP error', () => {
+    const credentials = {
+      password: 'NewPassword123!',
+      confirmPassword: 'NewPassword123!',
+    };
+    component.resetForm.setValue(credentials);
+
+    jest
+      .spyOn(authService, 'resetPassword')
+      .mockReturnValue(throwError(() => ({ error: { message: 'Server error' } })));
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.onSubmit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error', 'Server error');
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.ForgetPassword]);
+  });
+
+  it('should show password mismatch error when passwords do not match', () => {
+    const form = component.resetForm;
+    form.get('password')?.setValue('abc123');
+    form.get('confirmPassword')?.setValue('xyz789');
+
+    component.passwordMatchValidator(form);
+
+    expect(form.get('confirmPassword')?.errors?.['passwordMismatch']).toBeTruthy();
+  });
+
+  it('should clear password mismatch error when passwords match and previously had error', () => {
+    const form = component.resetForm;
+    const confirmPassword = form.get('confirmPassword');
+
+    confirmPassword?.setErrors({ passwordMismatch: true });
+    form.get('password')?.setValue('abc123');
+    confirmPassword?.setValue('abc123');
+
+    component.passwordMatchValidator(form);
+
+    expect(confirmPassword?.errors).toBeNull();
+  });
+
+  it('should not set passwordMismatch error if confirmPassword is empty', () => {
+    const form = component.resetForm;
+    form.get('password')?.setValue('Password123!');
+    form.get('confirmPassword')?.setValue('');
+
+    component.passwordMatchValidator(form);
+
+    expect(form.get('confirmPassword')?.hasError('passwordMismatch')).toBe(false);
+  });
+
+  it('should return validation error message via getError()', () => {
+    const control = component.resetForm.get('password');
+    control?.setValue('');
+    control?.markAsTouched();
+
+    jest.spyOn(validationErrorService, 'getErrorMessage').mockReturnValue('Password is required.');
+
+    const error = component.getError('password');
+    expect(error).toBe('Password is required.');
+  });
+
+  it('should return null from getError() if field config not found', () => {
+    jest.spyOn(validationErrorService, 'getErrorMessage').mockReturnValue(null);
+    const error = component.getError('nonExistent');
+    expect(error).toBeNull();
+  });
+
+  it('should use SEND_RESET_LINK_CONFIG for button config', () => {
+    expect(component.sendResetLinkButton).toBe(SEND_RESET_LINK_CONFIG);
+  });
+
+  it('should show error and navigate if verifyResetToken returns data false', () => {
+    jest
+      .spyOn(authService, 'verifyResetToken')
+      .mockReturnValue(
+        of({ result: true, statusCode: 200, message: 'Token invalid', data: false }),
+      );
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.ngOnInit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error! 200', 'Token invalid');
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.ResetLinkInvalid]);
+  });
+
+  it('should handle error if verifyResetToken throws error', () => {
+    jest
+      .spyOn(authService, 'verifyResetToken')
+      .mockReturnValue(throwError(() => ({ error: { message: 'Invalid or expired token' } })));
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.ngOnInit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error', 'Invalid or expired token');
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.ResetLinkInvalid]);
+  });
+
+  it('should show error snackbar and navigate if statusCode is not 200 but result is true', () => {
+    const credentials = {
+      password: 'NewPassword123!',
+      confirmPassword: 'NewPassword123!',
+    };
+    component.resetForm.setValue(credentials);
+
+    jest
+      .spyOn(authService, 'resetPassword')
+      .mockReturnValue(
+        of({ result: true, statusCode: 500, message: 'Server responded with error', data: null }),
+      );
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.onSubmit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error! 500', 'Server responded with error');
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.ForgetPassword]);
+  });
+
+  it('should show error snackbar and navigate if result is false even with statusCode 200', () => {
+    const credentials = {
+      password: 'NewPassword123!',
+      confirmPassword: 'NewPassword123!',
+    };
+    component.resetForm.setValue(credentials);
+
+    jest
+      .spyOn(authService, 'resetPassword')
+      .mockReturnValue(
+        of({ result: false, statusCode: 200, message: 'Unexpected failure', data: null }),
+      );
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.onSubmit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error! 200', 'Unexpected failure');
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.ForgetPassword]);
+  });
+  it('should navigate to ResetLinkInvalid if no resetToken is present', () => {
+    const activatedRoute = TestBed.inject(ActivatedRoute);
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    // Override queryParamMap to return null
+    activatedRoute.snapshot.queryParamMap.get = jest.fn().mockReturnValue(null);
+
+    component.ngOnInit();
+
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.ResetLinkInvalid]);
+  });
+  it('should show default error and navigate when verifyResetToken throws error without message', () => {
+    jest.spyOn(authService, 'verifyResetToken').mockReturnValue(
+      throwError(() => ({})), // no error.message
+    );
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.ngOnInit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error', PlatformMessages.errorMessage);
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.ResetLinkInvalid]);
+  });
+
+  it('should show default success message if res.message is missing on successful reset', () => {
+    const credentials = {
+      password: 'NewPassword123!',
+      confirmPassword: 'NewPassword123!',
+    };
+    component.resetForm.setValue(credentials);
+
+    jest
+      .spyOn(authService, 'resetPassword')
+      .mockReturnValue(of({ result: true, statusCode: 200, message: '', data: null }));
+
+    const successSpy = jest.spyOn(snackbarService, 'showSuccess');
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.onSubmit();
+
+    expect(successSpy).toHaveBeenCalledWith('Success', PlatformMessages.passwordResetSuccess);
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.Login]);
+  });
+
+  it('should use default error message when verifyResetToken error has no message', () => {
+    jest.spyOn(authService, 'verifyResetToken').mockReturnValue(
+      throwError(() => ({ error: {} })), // no message inside error
+    );
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.ngOnInit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error', PlatformMessages.errorMessage);
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.ResetLinkInvalid]);
+  });
+
+  it('should use default error message when resetPassword response has no message and fails', () => {
+    const credentials = {
+      password: 'NewPassword123!',
+      confirmPassword: 'NewPassword123!',
+    };
+    component.resetForm.setValue(credentials);
+
+    jest.spyOn(authService, 'resetPassword').mockReturnValue(
+      of({ result: false, statusCode: 400, message: '', data: null }), // message is null
+    );
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.onSubmit();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      `${PlatformMessages.errorTitle} 400`,
+      PlatformMessages.errorMessage,
+    );
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.ForgetPassword]);
+  });
+
+  it('should use default error message when resetPassword throws error without message', () => {
+    const credentials = {
+      password: 'NewPassword123!',
+      confirmPassword: 'NewPassword123!',
+    };
+    component.resetForm.setValue(credentials);
+
+    jest.spyOn(authService, 'resetPassword').mockReturnValue(
+      throwError(() => ({})), // no error object at all
+    );
+
+    const errorSpy = jest.spyOn(snackbarService, 'showError');
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.onSubmit();
+
+    expect(errorSpy).toHaveBeenCalledWith('Error', PlatformMessages.errorMessage);
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.ForgetPassword]);
   });
 });

--- a/src/app/core/auth/components/reset-password/reset-password.component.ts
+++ b/src/app/core/auth/components/reset-password/reset-password.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
@@ -40,7 +40,7 @@ import { Navigations } from '../../../../shared/enums/navigation';
     '../login/login.component.scss',
   ],
 })
-export class ResetPasswordComponent {
+export class ResetPasswordComponent implements OnInit, OnDestroy {
   private readonly fb = inject(FormBuilder);
   private readonly validationErrorService = inject(ValidationErrorService);
   private readonly authService = inject(ForgotResetPasswordService);
@@ -72,7 +72,10 @@ export class ResetPasswordComponent {
 
   ngOnInit(): void {
     this.resetToken = this.route.snapshot.queryParamMap.get('token') || '';
+    this.resetLinkValidation();
+  }
 
+  resetLinkValidation() {
     if (!this.resetToken) {
       this.router.navigate([Navigations.ResetLinkInvalid]);
       return;
@@ -163,5 +166,10 @@ export class ResetPasswordComponent {
           this.router.navigate([Navigations.ForgetPassword]);
         },
       });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/core/auth/components/reset-password/reset-password.component.ts
+++ b/src/app/core/auth/components/reset-password/reset-password.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { FilledButtonComponent } from '../../../../shared/components/filled-button/filled-button.component';
@@ -14,6 +14,11 @@ import { TogglePasswordDirective } from '../toggle-password.directive';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { ValidationErrorService } from '../../../../shared/service/validation-error/validation-error.service';
+import { ForgotResetPasswordService } from '../../services/forgot-reset-password.service';
+import { Subject, takeUntil } from 'rxjs';
+import { SnackbarService } from '../../../../shared/service/snackbar/snackbar.service';
+import { PlatformMessages } from '../../../../utils/constants';
+import { Navigations } from '../../../../shared/enums/navigation';
 
 @Component({
   selector: 'app-reset-password',
@@ -36,14 +41,21 @@ import { ValidationErrorService } from '../../../../shared/service/validation-er
   ],
 })
 export class ResetPasswordComponent {
-  private readonly fb = inject(FormBuilder); // For creating form group
+  private readonly fb = inject(FormBuilder);
   private readonly validationErrorService = inject(ValidationErrorService);
+  private readonly authService = inject(ForgotResetPasswordService);
+  private readonly snackbarService = inject(SnackbarService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
 
   resetFields = RESET_PASSWORD_FORM_FIELD;
-  resetForm: FormGroup;
   sendResetLinkButton = SEND_RESET_LINK_CONFIG;
 
-  // Initializes form controls and attaches validator
+  resetForm: FormGroup;
+  resetToken: string = '';
+
+  private readonly destroy$ = new Subject<void>();
+
   constructor() {
     const formControls = this.resetFields.reduce(
       (acc, field) => {
@@ -58,9 +70,35 @@ export class ResetPasswordComponent {
     });
   }
 
-  // Tracks form fields by name to optimize rendering
-  trackByField(index: number, field: any): string {
-    return field.name;
+  ngOnInit(): void {
+    this.resetToken = this.route.snapshot.queryParamMap.get('token') || '';
+
+    if (!this.resetToken) {
+      this.router.navigate([Navigations.ResetLinkInvalid]);
+      return;
+    }
+
+    this.authService
+      .verifyResetToken(this.resetToken)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          if (!res.result || res.statusCode !== 200 || res.data === false) {
+            this.snackbarService.showError(
+              `${PlatformMessages.errorTitle} ${res.statusCode}`,
+              res.message || PlatformMessages.errorMessage,
+            );
+
+            this.router.navigate([Navigations.ResetLinkInvalid]);
+          }
+        },
+        error: (err) => {
+          const message = err?.error?.message || PlatformMessages.errorMessage;
+          this.snackbarService.showError('Error', message);
+
+          this.router.navigate([Navigations.ResetLinkInvalid]);
+        },
+      });
   }
 
   getError(fieldName: string): string | null {
@@ -78,7 +116,6 @@ export class ResetPasswordComponent {
     if (confirmPasswordControl?.value && password !== confirmPasswordControl?.value) {
       confirmPasswordControl?.setErrors({ passwordMismatch: true });
     } else {
-      // Clear error if previously set and now matched
       if (confirmPasswordControl?.hasError('passwordMismatch')) {
         confirmPasswordControl.setErrors(null);
       }
@@ -86,7 +123,6 @@ export class ResetPasswordComponent {
     return null;
   }
 
-  // Handles form submission and simulates API call
   onSubmit(): void {
     if (this.resetForm.invalid) {
       this.resetForm.markAllAsTouched();
@@ -95,7 +131,37 @@ export class ResetPasswordComponent {
 
     const credentials: ResetCredential = {
       password: this.resetForm.value.password,
-      confirmPassword: this.resetForm.value.confirmPassword,
+      resetPasswordToken: this.resetToken,
     };
+
+    this.authService
+      .resetPassword(credentials)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          if (!res.result || res.statusCode !== 200) {
+            this.snackbarService.showError(
+              `${PlatformMessages.errorTitle} ${res.statusCode}`,
+              res.message || PlatformMessages.errorMessage,
+            );
+
+            this.router.navigate([Navigations.ForgetPassword]);
+            return;
+          }
+
+          this.snackbarService.showSuccess(
+            'Success',
+            res.message || PlatformMessages.passwordResetSuccess,
+          );
+
+          this.router.navigate([Navigations.Login]);
+        },
+        error: (err) => {
+          const message = err?.error?.message || PlatformMessages.errorMessage;
+          this.snackbarService.showError('Error', message);
+
+          this.router.navigate([Navigations.ForgetPassword]);
+        },
+      });
   }
 }

--- a/src/app/core/auth/interfaces/forgot-reset-password.interface.ts
+++ b/src/app/core/auth/interfaces/forgot-reset-password.interface.ts
@@ -1,6 +1,6 @@
 export interface ResetCredential {
   password: string;
-  confirmPassword: string;
+  resetPasswordToken?: string;
 }
 
 export interface ForgotCredential {

--- a/src/app/core/auth/interfaces/register.interface.ts
+++ b/src/app/core/auth/interfaces/register.interface.ts
@@ -1,8 +1,11 @@
 /**
  * Interface for register credentials
  */
-export interface RegisterCredentials {
+export interface RegisterCredential {
   fullName: string;
+  userName: string;
   email: string;
   password: string;
+  confirmPassword: string;
+  bio?: string;
 }

--- a/src/app/core/auth/services/forgot-reset-password.service.spec.ts
+++ b/src/app/core/auth/services/forgot-reset-password.service.spec.ts
@@ -1,0 +1,91 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ForgotResetPasswordService } from './forgot-reset-password.service';
+import { ForgotCredential, ResetCredential } from '../interfaces/forgot-reset-password.interface';
+import { ApiResponse } from '../../../shared/interfaces/api-response.interface';
+import { EndPoints } from '../../../shared/enums/end-point.enum';
+import { environment } from '../../../../environments/environment.dev';
+
+describe('ForgotResetPasswordService', () => {
+  let service: ForgotResetPasswordService;
+  let httpMock: HttpTestingController;
+
+  const baseUrl = `${environment.baseUrl}`;
+
+  const forgotPayload: ForgotCredential = {
+    email: 'user@example.com',
+  };
+
+  const resetPayload: ResetCredential = {
+    password: 'NewPass123!',
+    resetPasswordToken: 'abc123token',
+  };
+
+  const mockNullResponse: ApiResponse<null> = {
+    result: true,
+    statusCode: 200,
+    message: 'Success',
+    data: null,
+  };
+
+  const mockBooleanResponse: ApiResponse<boolean> = {
+    result: true,
+    statusCode: 200,
+    message: 'Valid token',
+    data: true,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ForgotResetPasswordService],
+    });
+    service = TestBed.inject(ForgotResetPasswordService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should send reset link via POST', () => {
+    service.sendResetLink(forgotPayload).subscribe((response) => {
+      expect(response).toEqual(mockNullResponse);
+    });
+
+    const req = httpMock.expectOne(`${baseUrl}/${EndPoints.ForgotPassword}`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(forgotPayload);
+
+    req.flush(mockNullResponse);
+  });
+
+  it('should reset password via POST', () => {
+    service.resetPassword(resetPayload).subscribe((response) => {
+      expect(response).toEqual(mockNullResponse);
+    });
+
+    const req = httpMock.expectOne(`${baseUrl}/${EndPoints.ResetPassword}`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(resetPayload);
+
+    req.flush(mockNullResponse);
+  });
+
+  it('should verify reset token via POST', () => {
+    const token = 'verifyToken123';
+    service.verifyResetToken(token).subscribe((response) => {
+      expect(response).toEqual(mockBooleanResponse);
+    });
+
+    const req = httpMock.expectOne(`${baseUrl}/${EndPoints.VerifyTokenRestPassword}`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ resetPasswordToken: token });
+
+    req.flush(mockBooleanResponse);
+  });
+});

--- a/src/app/core/auth/services/register.service.spec.ts
+++ b/src/app/core/auth/services/register.service.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed } from '@angular/core/testing';
+import { RegisterService } from './register.service';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { RegisterCredential } from '../interfaces/register.interface';
+import { ApiResponse } from '../../../shared/interfaces/api-response.interface';
+import { EndPoints } from '../../../shared/enums/end-point.enum';
+import { environment } from '../../../../environments/environment.dev';
+
+describe('RegisterService', () => {
+  let service: RegisterService;
+  let httpMock: HttpTestingController;
+
+  const mockCredentials: RegisterCredential = {
+    fullName: 'Jane Doe',
+    userName: 'jane_doe',
+    email: 'jane@example.com',
+    password: 'SecurePass123!',
+    confirmPassword: 'SecurePass123!',
+    bio: 'A test user',
+  };
+
+  const mockResponse: ApiResponse<null> = {
+    result: true,
+    statusCode: 201,
+    message: 'User registered successfully',
+    data: null,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [RegisterService],
+    });
+
+    service = TestBed.inject(RegisterService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify(); // Make sure no pending requests
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should send POST request to register user with correct payload and return expected response', () => {
+    service.registerUser(mockCredentials).subscribe((response) => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne(`${environment.baseUrl}/${EndPoints.RegisterUser}`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(mockCredentials);
+
+    req.flush(mockResponse);
+  });
+});

--- a/src/app/core/auth/services/register.service.ts
+++ b/src/app/core/auth/services/register.service.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiResponse } from '../../../shared/interfaces/api-response.interface';
+import { EndPoints } from '../../../shared/enums/end-point.enum';
+import { environment } from '../../../../environments/environment.dev';
+import { RegisterCredential } from '../interfaces/register.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RegisterService {
+  private readonly http = inject(HttpClient);
+
+  registerUser(credentials: RegisterCredential): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(
+      `${environment.baseUrl}/${EndPoints.RegisterUser}`,
+      credentials,
+    );
+  }
+}

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -205,3 +205,7 @@ export const DEBOUNCE_TIME = 500;
 export const USER_EXPORT_FILE_PREFIX = 'User';
 
 export const EXPORT_FILE_NAME_TEMPLATE = '{prefix}_export_{date}.xlsx';
+
+export const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/jpg', 'image/gif'];
+
+export const MAX_FILE_UPLOAD_SIZE = 10 * 1024 * 1024;

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -195,6 +195,7 @@ export const PlatformMessages = {
   passwordResetSuccess: `Password reset successfully.`,
   noDataAvailable: `No data available to export.`,
   errorExport: `Export failed.`,
+  registerSuccessfully: `Register Successfully!!`,
 };
 
 export const DEFAULT_LAST_LOGIN_DATE = '0001-01-01T00:00:00';


### PR DESCRIPTION
<img width="1919" height="625" alt="image" src="https://github.com/user-attachments/assets/bdfc3689-db3b-43f3-9f3a-05e7ad69b197" />

successfull register after:
<img width="1536" height="912" alt="image" src="https://github.com/user-attachments/assets/4ebe4726-a8d5-45dd-9a06-27aaf3be2e2a" />

reset password successfully 
<img width="1424" height="962" alt="image" src="https://github.com/user-attachments/assets/de9069ba-ea31-4f03-b0cf-5334ae7de7b1" />

reset link invalid 
<img width="1275" height="905" alt="image" src="https://github.com/user-attachments/assets/09a9060c-fa92-4fbe-b84e-811b38031ae9" />

password reset link successfully 
<img width="1316" height="945" alt="image" src="https://github.com/user-attachments/assets/1900dedf-2c08-4474-8e14-667360a61432" />

register page 
<img width="1071" height="982" alt="image" src="https://github.com/user-attachments/assets/5ff88ce1-9f9e-4dd2-8078-bea0390d9e3a" />

add user form 
<img width="703" height="577" alt="image" src="https://github.com/user-attachments/assets/1db96f3b-8336-4a9c-aca0-d18da0986849" />

