### PR TITLE
Question pool List  UI and Global admin page style 

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,6 +12,7 @@ import { MasterLayoutComponent } from './pages/layout/master-layout/master-layou
 import { CardComponent } from './shared/components/card/card.component';
 import { UserManagementComponent } from './pages/admin/user-management/user-management.component';
 import { UnauthorizedComponent } from './shared/components/unauthorized/unauthorized.component';
+import { QuestionPoolComponent } from './pages/admin/question-pool/question-pool.component';
 
 export const routes: Routes = [
   {
@@ -67,6 +68,11 @@ export const routes: Routes = [
         component: UserManagementComponent,
         title: 'Quizeverse | User Management',
       },
+      {
+        path: Navigations.QuestionPool,
+        component: QuestionPoolComponent,
+        title: 'Quizeverse | Question Pool Management',
+      },
     ],
   },
   {
@@ -83,7 +89,7 @@ export const routes: Routes = [
     ],
   },
   {
-    path: 'unauthorized',
+    path: Navigations.Unauthorized,
     component: UnauthorizedComponent,
     title: 'QuizVerse | Unauthorized',
   },

--- a/src/app/core/auth/components/register/register.component.ts
+++ b/src/app/core/auth/components/register/register.component.ts
@@ -216,7 +216,7 @@ export class RegisterComponent implements OnDestroy {
   }
 
   // Handle cancel button click
-  // onCancel(): void {}
+  onCancel(): void {}
 
   ngOnDestroy(): void {
     this.destroy$.next();

--- a/src/app/pages/admin/question-pool/components/question-pool-listing/question-pool-listing.component.html
+++ b/src/app/pages/admin/question-pool/components/question-pool-listing/question-pool-listing.component.html
@@ -1,0 +1,14 @@
+<app-data-table
+  [columns]="columns"
+  [dataSource]="dataSource"
+  [totalItems]="totalItems"
+  [pageSize]="paginationConfig.pageSize"
+  [pageSizeOptions]="paginationConfig.pageSizeOptions"
+  [applyPaginator]="paginationConfig.applyPaginator"
+  [tableTitle]="tableTitle"
+  [tableDescription]="tableDescription"
+  (actionClick)="onActionClick($event)"
+  (pageChange)="onPageChange($event)"
+  (sortChange)="onSortChange($event)"
+>
+</app-data-table>

--- a/src/app/pages/admin/question-pool/components/question-pool-listing/question-pool-listing.component.spec.ts
+++ b/src/app/pages/admin/question-pool/components/question-pool-listing/question-pool-listing.component.spec.ts
@@ -1,0 +1,64 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { QuestionPoolListingComponent } from './question-pool-listing.component';
+import { TableComponent } from '../../../../../shared/components/table/table.component';
+import {
+  questionPoolColumnsConfig,
+  questionPoolMockData,
+  questionPoolPaginationConfig,
+} from '../../configs/question-pool-table.config';
+import { CommonModule } from '@angular/common';
+
+describe('QuestionPoolListingComponent', () => {
+  let component: QuestionPoolListingComponent;
+  let fixture: ComponentFixture<QuestionPoolListingComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CommonModule, TableComponent, QuestionPoolListingComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(QuestionPoolListingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have correct columns, paginationConfig, and dataSource', () => {
+    expect(component.columns).toEqual(questionPoolColumnsConfig);
+    expect(component.paginationConfig).toEqual(questionPoolPaginationConfig);
+    expect(component.dataSource).toEqual(questionPoolMockData);
+  });
+
+  it('should compute totalItems correctly', () => {
+    expect(component.totalItems).toBe(questionPoolMockData.length);
+  });
+
+  it('should compute tableTitle correctly', () => {
+    const expectedTitle = `Question Pool (${questionPoolMockData.length})`;
+    expect(component.tableTitle).toBe(expectedTitle);
+  });
+
+  it('should call onActionClick with correct parameters', () => {
+    const spy = jest.spyOn(component, 'onActionClick');
+    const mockEvent = { action: 'edit', row: questionPoolMockData[0] };
+    component.onActionClick(mockEvent);
+    expect(spy).toHaveBeenCalledWith(mockEvent);
+  });
+
+  it('should call onPageChange with correct parameters', () => {
+    const spy = jest.spyOn(component, 'onPageChange');
+    const mockEvent = { pageIndex: 1, pageSize: 10 };
+    component.onPageChange(mockEvent);
+    expect(spy).toHaveBeenCalledWith(mockEvent);
+  });
+
+  it('should call onSortChange with correct parameters', () => {
+    const spy = jest.spyOn(component, 'onSortChange');
+    const mockEvent = { active: 'title', direction: 'asc' };
+    component.onSortChange(mockEvent);
+    expect(spy).toHaveBeenCalledWith(mockEvent);
+  });
+});

--- a/src/app/pages/admin/question-pool/components/question-pool-listing/question-pool-listing.component.ts
+++ b/src/app/pages/admin/question-pool/components/question-pool-listing/question-pool-listing.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { TableComponent } from '../../../../../shared/components/table/table.component';
+import {
+  questionPoolColumnsConfig,
+  questionPoolMockData,
+  questionPoolPaginationConfig,
+} from '../../configs/question-pool-table.config';
+import { TableData } from '../../../../../shared/interfaces/table-component.interface';
+
+@Component({
+  selector: 'app-question-pool-table',
+  imports: [TableComponent],
+  templateUrl: './question-pool-listing.component.html',
+  styleUrl: './question-pool-listing.component.scss',
+})
+export class QuestionPoolListingComponent {
+  columns = questionPoolColumnsConfig;
+  paginationConfig = questionPoolPaginationConfig;
+  dataSource = questionPoolMockData;
+  totalItems = this.dataSource.length;
+  tableTitle = 'Question Pool (' + this.totalItems + ')';
+  tableDescription = 'Manage and organize questions for quizzes and battles';
+
+  onActionClick(event: { action: string; row: TableData }) {}
+
+  onPageChange(event: { pageIndex: number; pageSize: number }) {}
+
+  onSortChange(event: { active: string; direction: string }) {}
+}

--- a/src/app/pages/admin/question-pool/configs/question-pool-table.config.ts
+++ b/src/app/pages/admin/question-pool/configs/question-pool-table.config.ts
@@ -1,0 +1,152 @@
+import { ColumnDef, TableData } from '../../../../shared/interfaces/table-component.interface';
+import { tablePaginationConfig } from '../../../../utils/constants';
+
+export const questionPoolPaginationConfig = {
+  pageSize: tablePaginationConfig.PageSize,
+  pageSizeOptions: tablePaginationConfig.PageSizeOptions,
+  applyPaginator: true,
+};
+
+export const questionPoolColumnsConfig: ColumnDef[] = [
+  {
+    key: 'questionPool',
+    label: 'Question',
+    type: 'question-pool',
+    isSortable: false,
+  },
+  {
+    key: 'type',
+    label: 'Type',
+    type: 'tag',
+    isSortable: false,
+  },
+  {
+    key: 'category',
+    label: 'Category',
+    type: 'text',
+    isSortable: false,
+  },
+  {
+    key: 'difficulty',
+    label: 'Difficulty',
+    type: 'tag',
+    isSortable: false,
+  },
+  {
+    key: 'actions',
+    label: 'Actions',
+    type: 'button',
+    isSortable: false,
+  },
+];
+
+export const questionPoolMockData: TableData[] = [
+  {
+    questionPool: [
+      {
+        question: 'What is the capital of France?',
+        correctAnswer: 'Paris',
+      },
+    ],
+    type: {
+      tagConfig: {
+        id: 'multiple-choice',
+        label: 'Multiple Choice',
+        backgroundColor: 'light-gray-color',
+        textColor: 'black',
+        hasBorder: true,
+      },
+    },
+    category: 'Geography',
+    difficulty: {
+      tagConfig: {
+        id: 'easy',
+        label: 'Easy',
+        backgroundColor: 'light-green',
+        textColor: 'green',
+      },
+    },
+    actions: ['visibility', 'edit', 'delete'],
+  },
+  {
+    questionPool: [
+      {
+        question: 'What is 2 + 2?',
+        correctAnswer: '4',
+      },
+    ],
+    type: {
+      tagConfig: {
+        id: 'multiple-choice',
+        label: 'Multiple Choice',
+        backgroundColor: 'light-gray-color',
+        textColor: 'black',
+        hasBorder: true,
+      },
+    },
+    category: 'Mathematics',
+    difficulty: {
+      tagConfig: {
+        id: 'easy',
+        label: 'Easy',
+        backgroundColor: 'light-green',
+        textColor: 'green',
+      },
+    },
+    actions: ['visibility', 'edit', 'delete'],
+  },
+  {
+    questionPool: [
+      {
+        question: 'What is the derivative of sin(x)?',
+        correctAnswer: 'cos(x)',
+      },
+    ],
+    type: {
+      tagConfig: {
+        id: 'multiple-choice',
+        label: 'Multiple Choice',
+        backgroundColor: 'light-gray-color',
+        textColor: 'black',
+        hasBorder: true,
+      },
+    },
+    category: 'Calculus',
+    difficulty: {
+      tagConfig: {
+        id: 'medium',
+        label: 'Medium',
+        backgroundColor: 'light-yellow',
+        textColor: 'orange',
+      },
+    },
+    actions: ['visibility', 'edit', 'delete'],
+  },
+  {
+    questionPool: [
+      {
+        question: 'Explain the theory of relativity.',
+        correctAnswer: 'E = mc² and more...',
+      },
+    ],
+    type: {
+      tagConfig: {
+        id: 'descriptive',
+        label: 'Descriptive',
+        backgroundColor: 'light-gray-color',
+        textColor: 'black',
+        hasBorder: true,
+      },
+    },
+    category: 'Physics',
+    difficulty: {
+      tagConfig: {
+        id: 'hard',
+        label: 'Hard',
+        backgroundColor: 'light-red',
+        textColor: 'red',
+      },
+    },
+    actions: ['visibility', 'edit', 'delete'],
+  },
+];

--- a/src/app/pages/admin/question-pool/configs/question-pool.config.ts
+++ b/src/app/pages/admin/question-pool/configs/question-pool.config.ts
@@ -1,0 +1,23 @@
+import { ButtonConfig } from '../../../../shared/interfaces/button-config.interface';
+
+// Header section config for Question Pool Management page
+export const questionPoolHeaderConfig = {
+  icon: 'folder_copy',
+  title: 'Question Pool Management',
+  subtitle: 'Manage questions for quizzes and battles',
+  theme: 'quizDifficulty' as const,
+};
+
+// Config for the search input field
+export const searchInputConfig = {
+  placeholder: 'Search questions...',
+};
+
+// Config for the "Add Question Pool" button
+export const addQuestionButtonConfig: ButtonConfig = {
+  label: 'Add Question',
+  matIcon: 'add',
+  iconFontSet: 'material-icons',
+  variant: 'secondary',
+  fontWeight: 500,
+};

--- a/src/app/pages/admin/question-pool/question-pool.component.html
+++ b/src/app/pages/admin/question-pool/question-pool.component.html
@@ -1,0 +1,65 @@
+<main class="admin-management-page">
+  <h2 class="admin-page-heading">Question Pool</h2>
+  <div class="admin-page-header">
+    <app-page-header
+      [icon]="questionPoolConfig.icon"
+      [title]="questionPoolConfig.title"
+      [subtitle]="questionPoolConfig.subtitle"
+      [theme]="questionPoolConfig.theme"
+    ></app-page-header>
+  </div>
+  <div class="admin-management-toolbar">
+    <div class="flex gap-4 serach-container">
+      <app-search-input
+        [placeholder]="searchInputConfig.placeholder"
+        [control]="searchControl"
+        (search)="onSearchInputChange($event)"
+        class="question-pool-search"
+      ></app-search-input>
+      <div class="add-question-btn-tablet">
+        <app-filled-button [filledButtonConfig]="addQuestionButtonConfig"></app-filled-button>
+      </div>
+    </div>
+
+    <div class="w-100 flex filter-btn-container">
+      <div class="question-pool-filters">
+        <!-- Category Filter -->
+        <mat-form-field appearance="outline" class="filter-select">
+          <mat-select
+            [(value)]="selectedCategory"
+            (selectionChange)="onFilterChange()"
+            placeholder="All Category"
+          >
+            <mat-option [value]="''">All Category</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <!-- Difficulty Filter -->
+        <mat-form-field appearance="outline" class="filter-select">
+          <mat-select
+            [(value)]="selectedDifficulty"
+            (selectionChange)="onFilterChange()"
+            placeholder="All Difficulty"
+          >
+            <mat-option [value]="''">All Difficulty</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <!-- Type Filter -->
+        <mat-form-field appearance="outline" class="filter-select">
+          <mat-select
+            [(value)]="selectedType"
+            (selectionChange)="onFilterChange()"
+            placeholder="All Types"
+          >
+            <mat-option [value]="''">All Types</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="add-question-btn">
+      <app-filled-button [filledButtonConfig]="addQuestionButtonConfig"></app-filled-button>
+    </div>
+  </div>
+  <app-question-pool-table></app-question-pool-table>
+</main>

--- a/src/app/pages/admin/question-pool/question-pool.component.scss
+++ b/src/app/pages/admin/question-pool/question-pool.component.scss
@@ -1,0 +1,83 @@
+.admin-management-toolbar {
+  display: flex;
+  gap: 16px;
+  flex: 1;
+
+  .serach-container,
+  .filter-btn-container {
+    width: 100%;
+  }
+
+  .question-pool-search {
+    flex: 1;
+    width: 100%;
+
+    @media (max-width: 726px) {
+      width: 100%;
+    }
+  }
+
+  .question-pool-filters {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    width: 100%;
+
+    .filter-select {
+      min-width: 160px;
+
+      @media (max-width: 726px) {
+        width: 100%;
+      }
+    }
+
+    @media (max-width: 726px) {
+      flex-direction: column;
+      width: 100%;
+    }
+  }
+
+  .add-question-btn {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    margin-left: auto;
+    max-width: 156px;
+    width: 100%;
+
+    @media (max-width: 726px) {
+      width: 100%;
+      justify-content: flex-end;
+    }
+
+    @media (max-width: 1500px) {
+      display: none;
+    }
+
+    @media (max-width: 580px) {
+      display: inline;
+      max-width: 100%;
+    }
+  }
+
+  .add-question-btn-tablet {
+    display: none;
+
+    @media (max-width: 1500px) {
+      display: inline;
+    }
+
+    @media (max-width: 580px) {
+      display: none;
+    }
+  }
+
+  @media (max-width: 1500px) {
+    flex-wrap: wrap;
+  }
+
+  @media (max-width: 726px) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/src/app/pages/admin/question-pool/question-pool.component.spec.ts
+++ b/src/app/pages/admin/question-pool/question-pool.component.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { QuestionPoolComponent } from './question-pool.component';
+import { PageHeaderComponent } from '../../../shared/components/page-header/page-header.component';
+import { SearchInputComponent } from '../../../shared/components/search-input/search-input.component';
+import { FilledButtonComponent } from '../../../shared/components/filled-button/filled-button.component';
+import { MatSelectModule } from '@angular/material/select';
+import { QuestionPoolListingComponent } from './components/question-pool-listing/question-pool-listing.component';
+import { ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+
+describe('QuestionPoolComponent', () => {
+  let component: QuestionPoolComponent;
+  let fixture: ComponentFixture<QuestionPoolComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        QuestionPoolComponent,
+        PageHeaderComponent,
+        SearchInputComponent,
+        FilledButtonComponent,
+        MatSelectModule,
+        QuestionPoolListingComponent,
+        ReactiveFormsModule,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(QuestionPoolComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize config variables', () => {
+    expect(component.questionPoolConfig).toBeDefined();
+    expect(component.searchInputConfig).toBeDefined();
+    expect(component.addQuestionButtonConfig).toBeDefined();
+  });
+
+  it('should initialize FormControl with null', () => {
+    expect(component.searchControl.value).toBeNull();
+  });
+
+  it('should initialize filter selections as undefined', () => {
+    expect(component.selectedCategory).toBeUndefined();
+    expect(component.selectedDifficulty).toBeUndefined();
+    expect(component.selectedType).toBeUndefined();
+  });
+
+  it('should render page header component', () => {
+    const header = fixture.debugElement.query(By.directive(PageHeaderComponent));
+    expect(header).toBeTruthy();
+  });
+
+  it('should render search input component', () => {
+    const searchInput = fixture.debugElement.query(By.directive(SearchInputComponent));
+    expect(searchInput).toBeTruthy();
+  });
+
+  it('should render filled button component', () => {
+    const filledButton = fixture.debugElement.query(By.directive(FilledButtonComponent));
+    expect(filledButton).toBeTruthy();
+  });
+
+  it('should render question pool listing component', () => {
+    const table = fixture.debugElement.query(By.directive(QuestionPoolListingComponent));
+    expect(table).toBeTruthy();
+  });
+  it('should call onSearchInputChange without error', () => {
+    const value = 'test query';
+    expect(() => component.onSearchInputChange(value)).not.toThrow();
+  });
+
+  it('should call onFilterChange without error', () => {
+    expect(() => component.onFilterChange()).not.toThrow();
+  });
+});

--- a/src/app/pages/admin/question-pool/question-pool.component.ts
+++ b/src/app/pages/admin/question-pool/question-pool.component.ts
@@ -1,0 +1,43 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { PageHeaderComponent } from '../../../shared/components/page-header/page-header.component';
+import { SearchInputComponent } from '../../../shared/components/search-input/search-input.component';
+import { FilledButtonComponent } from '../../../shared/components/filled-button/filled-button.component';
+import {
+  addQuestionButtonConfig,
+  questionPoolHeaderConfig,
+  searchInputConfig,
+} from './configs/question-pool.config';
+import { FormControl } from '@angular/forms';
+import { MatSelectModule } from '@angular/material/select';
+import { QuestionPoolListingComponent } from './components/question-pool-listing/question-pool-listing.component';
+
+@Component({
+  selector: 'app-question-pool',
+  imports: [
+    PageHeaderComponent,
+    SearchInputComponent,
+    FilledButtonComponent,
+    MatSelectModule,
+    QuestionPoolListingComponent,
+  ],
+  templateUrl: './question-pool.component.html',
+  styleUrl: './question-pool.component.scss',
+})
+export class QuestionPoolComponent {
+  // Header and button configs
+  questionPoolConfig = questionPoolHeaderConfig;
+  searchInputConfig = searchInputConfig;
+  addQuestionButtonConfig = addQuestionButtonConfig;
+
+  // Search input control
+  searchControl = new FormControl<string | null>(null);
+
+  // Filter selections
+  selectedCategory: number;
+  selectedDifficulty: number;
+  selectedType: number;
+
+  onSearchInputChange(value: string): void {}
+
+  onFilterChange() {}
+}

--- a/src/app/pages/admin/user-management/user-management.component.html
+++ b/src/app/pages/admin/user-management/user-management.component.html
@@ -1,6 +1,6 @@
-<main class="user-management">
-  <h2 class="page-heading">User Management</h2>
-  <div class="user-page-header">
+<main class="admin-management-page">
+  <h2 class="admin-page-heading">User Management</h2>
+  <div class="admin-page-header">
     <app-page-header
       [icon]="userConfig.icon"
       [title]="userConfig.title"
@@ -8,7 +8,7 @@
       [theme]="userConfig.theme"
     ></app-page-header>
   </div>
-  <div class="user-management-toolbar">
+  <div class="admin-management-toolbar">
     <app-search-input
       [placeholder]="searchInputConfig.placeholder"
       [control]="searchControl"

--- a/src/app/pages/admin/user-management/user-management.component.scss
+++ b/src/app/pages/admin/user-management/user-management.component.scss
@@ -1,31 +1,5 @@
-.user-management {
-  padding: 24px 32px;
-  background: var(--global-bg-gradient);
-  min-height: 100%;
-  @media (min-width: 1024px) {
-    width: calc(100vw - 283px);
-  }
-  .page-heading {
-    font-size: revert;
-    font-weight: revert;
-    margin-bottom: 24px;
-  }
-
-  .user-page-header {
-    margin-bottom: 24px;
-  }
-
-  .user-management-toolbar {
-    display: grid;
-    grid-template-columns: 1fr 2fr 1fr;
-    gap: 1rem;
-    align-items: center;
-    border-radius: 8px;
-    border: 0.5px solid #e2e8f0;
-    background-color: white;
-    margin-bottom: 24px;
-    padding: 24px;
-
+.admin-management-page {
+  .admin-management-toolbar {
     .user-management-search-bar {
       width: 100%;
     }
@@ -64,20 +38,12 @@
         gap: 16px;
         width: 100%;
       }
-      @media (max-width: 768px) {
-        padding: 16px;
-        @media (max-width: 480px) {
-          padding: 12px;
-          .user-management-btns {
-            flex-direction: column;
-            align-items: stretch;
-          }
+      @media (max-width: 480px) {
+        .user-management-btns {
+          flex-direction: column;
+          align-items: stretch;
         }
       }
     }
-  }
-
-  @media (max-width: 1036px) {
-    padding: 24px 16px;
   }
 }

--- a/src/app/services/admin/question-pool/question-pool.service.spec.ts
+++ b/src/app/services/admin/question-pool/question-pool.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { QuestionPoolService } from './question-pool.service';
+
+describe('QuestionPoolService', () => {
+  let service: QuestionPoolService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(QuestionPoolService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/admin/question-pool/question-pool.service.ts
+++ b/src/app/services/admin/question-pool/question-pool.service.ts
@@ -3,6 +3,4 @@ import { Injectable } from '@angular/core';
 @Injectable({
   providedIn: 'root',
 })
-export class QuestionPoolService {
-  constructor() {}
-}
+export class QuestionPoolService {}

--- a/src/app/services/admin/question-pool/question-pool.service.ts
+++ b/src/app/services/admin/question-pool/question-pool.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class QuestionPoolService {
+  constructor() {}
+}

--- a/src/app/shared/components/table/table.component.scss
+++ b/src/app/shared/components/table/table.component.scss
@@ -234,7 +234,7 @@
     .question-card {
       .question-text {
         font-size: 15px;
-        font-weight: 600;
+        font-weight: 500;
         color: #111827;
         margin: 0;
       }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -219,9 +219,52 @@ app-data-table {
   }
 }
 
+// all page common header styling (Admin Pages)
+.admin-management-page {
+  padding: 24px 32px;
+  background: var(--global-bg-gradient);
+  min-height: 100%;
+
+  @media (min-width: 1024px) {
+    width: calc(100vw - 283px);
+  }
+
+  .admin-page-heading {
+    font-size: revert;
+    font-weight: revert;
+    margin-bottom: 24px;
+  }
+
+  .admin-page-header {
+    margin-bottom: 24px;
+  }
+
+  .admin-management-toolbar {
+    display: grid;
+    grid-template-columns: 1fr 2fr 1fr;
+    gap: 1rem;
+    align-items: center;
+    border-radius: 8px;
+    border: 0.5px solid #e2e8f0;
+    background-color: white;
+    margin-bottom: 24px;
+    padding: 24px;
+
+    @media (max-width: 768px) {
+      padding: 16px;
+    }
+    @media (max-width: 480px) {
+      padding: 12px;
+    }
+  }
+  @media (max-width: 1036px) {
+    padding: 24px 16px;
+  }
+}
+
 //User Management Buttons
-.user-management {
-  .user-management-toolbar {
+.admin-management-page {
+  .admin-management-toolbar {
     .user-management-btns {
       .add-user,
       .export-users {
@@ -231,6 +274,17 @@ app-data-table {
           width: 100% !important;
           white-space: nowrap !important;
         }
+      }
+    }
+  }
+}
+
+//Question Pool Management Buttons
+.admin-management-page {
+  .admin-management-toolbar {
+    .add-question-btn {
+      button {
+        width: 100%;
       }
     }
   }


### PR DESCRIPTION
created the ui of Question pool List and add the global style of all admin page - apply that in user management component also

-- test case
<img width="955" height="342" alt="image" src="https://github.com/user-attachments/assets/391beb17-2659-4e6d-aeb4-88bf089751d9" />
<img width="1920" height="317" alt="image" src="https://github.com/user-attachments/assets/860e583c-a268-4e84-870d-7ef699af90f7" />
<img width="1920" height="372" alt="image" src="https://github.com/user-attachments/assets/805dd151-fbab-40e6-b376-90251afa93f6" />
<img width="1920" height="315" alt="image" src="https://github.com/user-attachments/assets/c87dbeca-a72b-4577-99ef-7c1a05bd576a" />

-- ui of question pool list
<img width="1918" height="945" alt="image" src="https://github.com/user-attachments/assets/934f892a-2928-4768-9aa8-15bc5ae43d8b" />
<img width="949" height="950" alt="image" src="https://github.com/user-attachments/assets/3c19b419-556d-459a-ab8f-266b00d2e8fc" />
<img width="614" height="949" alt="image" src="https://github.com/user-attachments/assets/51c797bf-e0d2-4736-a6dd-f80801f1616b" />
<img width="440" height="958" alt="image" src="https://github.com/user-attachments/assets/6028641e-9f16-4372-a3ac-3b3311858ffe" />
