### PR TITLE
adding browse quizzes list FE with all filters and search

### DIFF
--- a/src/app/pages/user/browse-quizzes/browse-quizzes.component.html
+++ b/src/app/pages/user/browse-quizzes/browse-quizzes.component.html
@@ -1,1 +1,174 @@
-<p>browse-quizzes works!</p>
+<div class="profile-page player-management-page">
+  <h2 class="player-page-heading">Browse Quizzes</h2>
+
+  <form [formGroup]="filtersForm">
+    <!-- Toolbar -->
+    <div class="player-management-toolbar">
+      <div class="flex flex-col gap-3 w-full">
+        <div class="flex flex-col gap-3 w-full">
+          <div class="flex gap-3 search-container">
+            <!-- Search Input -->
+            <app-search-input
+              [placeholder]="searchInputConfig.placeholder"
+              [control]="searchControl"
+              (search)="searchInputChange($event)"
+              class="browse-quiz-search"
+            ></app-search-input>
+
+            <!-- Filter Button (Large) -->
+            <div class="filter-btn-large">
+              <app-filled-button
+                [filledButtonConfig]="showFilterBtn"
+                (click)="toggleFilters()"
+              ></app-filled-button>
+            </div>
+          </div>
+
+          <!-- Top Filters (Category, Difficulty, Type, Actions) -->
+          <div class="w-100 flex filter-btn-container">
+            <div class="browse-quiz-filters">
+              <!-- Category -->
+              <mat-form-field appearance="outline" class="filter-select">
+                <mat-select
+                  formControlName="quizCategoryId"
+                  (selectionChange)="filterChange()"
+                  placeholder="All Category"
+                >
+                  <mat-option [value]="null">All Category</mat-option>
+                  @for (item of categoryList; track item.id) {
+                    <mat-option [value]="item.id">{{ item.name }}</mat-option>
+                  }
+                </mat-select>
+              </mat-form-field>
+
+              <!-- Difficulty -->
+              <mat-form-field appearance="outline" class="filter-select">
+                <mat-select
+                  formControlName="quizDifficultyLevelId"
+                  (selectionChange)="filterChange()"
+                  placeholder="All Difficulty"
+                >
+                  <mat-option [value]="null">All Difficulty</mat-option>
+                  @for (item of difficultyList; track item.id) {
+                    <mat-option [value]="item.id">{{ item.name }}</mat-option>
+                  }
+                </mat-select>
+              </mat-form-field>
+
+              <!-- Type -->
+              <mat-form-field appearance="outline" class="filter-select">
+                <mat-select
+                  formControlName="browseQuizzesSorting"
+                  (selectionChange)="filterChange()"
+                  placeholder="All Types"
+                >
+                  <mat-option [value]="null">All Types</mat-option>
+                  @for (item of typeList; track item.id) {
+                    <mat-option [value]="item.id">{{ item.name }}</mat-option>
+                  }
+                </mat-select>
+              </mat-form-field>
+
+              <!-- Action Buttons -->
+              <div class="flex gap-3 w-full">
+                <div class="text-nowrap quiz-btn-container">
+                  <app-outline-button
+                    [outlineButtonConfig]="clearFilterBtn"
+                    (click)="clearFilters()"
+                  ></app-outline-button>
+                </div>
+                <div class="filter-btn-small quiz-btn-container">
+                  <app-filled-button
+                    [filledButtonConfig]="showFilterBtn"
+                    (click)="toggleFilters()"
+                  ></app-filled-button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Expandable Filters Panel -->
+        @if (showFiltersPanel) {
+          <div class="filters-panel" formGroupName="filterRanges">
+            <div class="slider-row">
+              <!-- Price Range -->
+              <div class="filter-group">
+                <label class="filter-label">
+                  Price Range: ₹{{ filtersForm.get('filterRanges.minPrice')?.value }} - ₹{{
+                    filtersForm.get('filterRanges.maxPrice')?.value
+                  }}
+                </label>
+                <mat-slider min="0" max="1000" step="100" class="slider" (change)="filterChange()">
+                  <input matSliderStartThumb formControlName="minPrice" />
+                  <input matSliderEndThumb formControlName="maxPrice" />
+                </mat-slider>
+              </div>
+
+              <!-- Rating -->
+              <div class="filter-group">
+                <label class="filter-label">
+                  Minimum Rating:
+                  {{ filtersForm.get('filterRanges.minRating')?.value }} -
+                  {{ filtersForm.get('filterRanges.maxRating')?.value }} stars
+                </label>
+                <mat-slider min="0" max="5" step="0.5" class="slider" (change)="filterChange()">
+                  <input matSliderStartThumb formControlName="minRating" />
+                  <input matSliderEndThumb formControlName="maxRating" />
+                </mat-slider>
+              </div>
+
+              <!-- Duration -->
+              <div class="filter-group">
+                <label class="filter-label">
+                  Duration:
+                  {{ filtersForm.get('filterRanges.minTotalTime')?.value }} -
+                  {{ filtersForm.get('filterRanges.maxTotalTime')?.value }} minutes
+                </label>
+                <mat-slider min="2" max="180" step="1" class="slider" (change)="filterChange()">
+                  <input matSliderStartThumb formControlName="minTotalTime" />
+                  <input matSliderEndThumb formControlName="maxTotalTime" />
+                </mat-slider>
+              </div>
+            </div>
+
+            <!-- Tags -->
+            <div class="filter-group tag-section">
+              <label class="filter-label">All Available Tags</label>
+              <div class="tag-container">
+                @for (tag of allTags; track tag.id) {
+                  <app-tag
+                    class="tags"
+                    [tagConfig]="tag"
+                    (tagSelected)="tagSelected($event)"
+                    (tagClosed)="tagClosed($event)"
+                  ></app-tag>
+                }
+              </div>
+            </div>
+          </div>
+        }
+      </div>
+    </div>
+
+    <!-- Tabs -->
+    <div>
+      <app-common-tab
+        [tabs]="tabs"
+        [selectedIndex]="selectedTab()"
+        (tabChanged)="switchToTab($event)"
+        class="user-profile-tabs"
+      >
+      </app-common-tab>
+    </div>
+
+    @if (hasMoreResults) {
+      <div class="load-more-btn-container">
+        <app-outline-button
+          [outlineButtonConfig]="loadMoreBtnConfig"
+          (click)="loadMore()"
+        ></app-outline-button>
+      </div>
+    }
+  </form>
+</div>

--- a/src/app/pages/user/browse-quizzes/browse-quizzes.component.spec.ts
+++ b/src/app/pages/user/browse-quizzes/browse-quizzes.component.spec.ts
@@ -1,14 +1,82 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { BrowseQuizzesComponent } from './browse-quizzes.component';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+import { BrowseQuizzesService } from '../../../services/user/browse-quizzes/browse-quizzes.service';
+import { DropdownService } from '../../../shared/service/dropdown/dropdown.service';
+import { SnackbarService } from '../../../shared/service/snackbar/snackbar.service';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { DropDownType } from '../../../shared/enums/dropdown-types.enum';
+
+// Mock data
+const mockDropdowns = [
+  { id: 1, label: 'Mock Category' },
+  { id: 2, label: 'Mock Difficulty' },
+];
+
+const mockTags = [
+  { id: 1, label: 'Tag1' },
+  { id: 2, label: 'Tag2' },
+];
+
+const mockQuizResponse = {
+  result: true,
+  data: {
+    quizzes: [
+      {
+        id: 1,
+        title: 'Sample Quiz',
+        description: 'Test quiz',
+        categoryName: 'Science',
+        difficultyLevel: 'Easy',
+        rating: 4.5,
+        price: 10,
+        isFree: true,
+        totalQuestions: 10,
+        totalTime: 60,
+        tagIds: [1],
+        isAttempted: false,
+      },
+    ],
+    hasMore: true,
+    totalFeatured: 1,
+    totalAll: 2,
+    totalFree: 3,
+    totalPremium: 4,
+  },
+};
 
 describe('BrowseQuizzesComponent', () => {
   let component: BrowseQuizzesComponent;
   let fixture: ComponentFixture<BrowseQuizzesComponent>;
 
+  let browseQuizzesServiceMock: any;
+  let dropdownServiceMock: any;
+  let snackbarServiceMock: any;
+
   beforeEach(async () => {
+    browseQuizzesServiceMock = {
+      browseQuizzes: jest.fn().mockReturnValue(of(mockQuizResponse)),
+    };
+
+    dropdownServiceMock = {
+      getDropdownData: jest.fn().mockImplementation((type: number) => {
+        return type === 3 ? of(mockTags) : of(mockDropdowns);
+      }),
+    };
+
+    snackbarServiceMock = {
+      showError: jest.fn(),
+    };
+
     await TestBed.configureTestingModule({
-      imports: [BrowseQuizzesComponent],
+      imports: [ReactiveFormsModule, BrowseQuizzesComponent],
+      providers: [
+        { provide: BrowseQuizzesService, useValue: browseQuizzesServiceMock },
+        { provide: DropdownService, useValue: dropdownServiceMock },
+        { provide: SnackbarService, useValue: snackbarServiceMock },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BrowseQuizzesComponent);
@@ -16,7 +84,210 @@ describe('BrowseQuizzesComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create the component and fetch data on init', () => {
     expect(component).toBeTruthy();
+    expect(browseQuizzesServiceMock.browseQuizzes).toHaveBeenCalled();
+    expect(dropdownServiceMock.getDropdownData).toHaveBeenCalledTimes(3);
+  });
+
+  it('should switch tabs and fetch data', () => {
+    const fetchSpy = jest.spyOn(component, 'fetchQuizzesList');
+    component.switchToTab(1);
+    expect(component.selectedTab()).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('should handle search input with debounce', fakeAsync(() => {
+    const spy = jest.spyOn(component as any, 'fetchQuizzesList');
+    component.searchInputChange('angular');
+    tick(500);
+    expect(spy).toHaveBeenCalledWith(true);
+  }));
+
+  it('should toggle the filters panel', () => {
+    expect(component.showFiltersPanel).toBe(false);
+    component.toggleFilters();
+    expect(component.showFiltersPanel).toBe(true);
+  });
+
+  it('should clear all filters and reset form', () => {
+    const spy = jest.spyOn(component, 'fetchQuizzesList');
+
+    component.filtersForm.patchValue({
+      quizCategoryId: 1,
+      tagIds: [1],
+    });
+
+    component.clearFilters();
+
+    expect(component.filtersForm.value.quizCategoryId).toBeNull();
+    expect(component.filtersForm.value.tagIds).toBeNull();
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+
+  it('should fetch more quizzes when loadMore is called', () => {
+    const spy = jest.spyOn(component, 'fetchQuizzesList');
+    component.batchNumber = 1;
+    component.loadMore();
+    expect(component.batchNumber).toBe(2);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should apply tag selection and call filterChange', () => {
+    const spy = jest.spyOn(component, 'fetchQuizzesList');
+    component.tagSelected({ id: '2', label: 'Tag2', isSelected: true });
+    expect(component.filtersForm.value.tagIds).toContain(2);
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+
+  it('should remove a tag on tagClosed', () => {
+    component.filtersForm.patchValue({ tagIds: [1, 2] });
+    component.tagClosed({ id: '2', label: 'Tag2' });
+    expect(component.filtersForm.value.tagIds).toEqual([1]);
+  });
+
+  it('should handle error in fetchQuizzesList', () => {
+    browseQuizzesServiceMock.browseQuizzes.mockReturnValueOnce(throwError(() => 'error'));
+
+    component.fetchQuizzesList();
+
+    expect(snackbarServiceMock.showError).toHaveBeenCalled();
+  });
+
+  it('should unsubscribe on destroy', () => {
+    const destroySpy = jest.spyOn((component as any).destroy$, 'next');
+    const completeSpy = jest.spyOn((component as any).destroy$, 'complete');
+
+    component.ngOnDestroy();
+
+    expect(destroySpy).toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalled();
+  });
+
+  it('should load dropdowns and set category, difficulty, type lists and tags', fakeAsync(() => {
+    component.loadDropdowns();
+
+    tick();
+
+    expect(dropdownServiceMock.getDropdownData).toHaveBeenCalledWith(DropDownType.QuizCategory);
+    expect(dropdownServiceMock.getDropdownData).toHaveBeenCalledWith(DropDownType.QuizDifficulty);
+    expect(dropdownServiceMock.getDropdownData).toHaveBeenCalledWith(DropDownType.QuizTag);
+
+    expect(component.categoryList).toEqual(mockDropdowns);
+    expect(component.difficultyList).toEqual(mockDropdowns);
+    expect(component.typeList.length).toBeGreaterThan(0);
+    expect(component.allTags.length).toBe(mockTags.length);
+  }));
+
+  it('filterChange should reset batchNumber and call fetchQuizzesList with reset', () => {
+    const spy = jest.spyOn(component, 'fetchQuizzesList');
+    component.batchNumber = 5;
+
+    component.filterChange();
+
+    expect(component.batchNumber).toBe(1);
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+
+  it('tagSelected should add tag id when selected', () => {
+    const spy = jest.spyOn(component, 'filterChange');
+    component.filtersForm.patchValue({ tagIds: [] });
+
+    component.tagSelected({ id: '3', label: 'Tag3', isSelected: true });
+
+    expect(component.filtersForm.value.tagIds).toContain(3);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('tagSelected should not add tag id when isSelected is false', () => {
+    const spy = jest.spyOn(component, 'filterChange');
+    component.filtersForm.patchValue({ tagIds: [1] });
+
+    component.tagSelected({ id: '1', label: 'Tag1', isSelected: false });
+
+    expect(component.filtersForm.value.tagIds).toEqual([1]);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('clearFilters should reset form and deselect all tags', () => {
+    component.allTags = component.allTags.map((tag) => ({ ...tag, isSelected: true }));
+
+    component.clearFilters();
+
+    expect(component.filtersForm.value.quizCategoryId).toBeNull();
+    expect(component.filtersForm.value.tagIds).toBeNull();
+    expect(component.allTags.every((tag) => tag.isSelected === false)).toBe(true);
+  });
+
+  it('fetchQuizzesList sends correct payload to service', () => {
+    browseQuizzesServiceMock.browseQuizzes.mockClear();
+
+    component.searchControl.setValue('test search');
+    component.filtersForm.patchValue({
+      quizCategoryId: 5,
+      tagIds: [10, 20],
+      browseQuizzesFilterByType: null,
+    });
+
+    component.currentTabId.set('allQuizzes');
+
+    const expectedPayload = {
+      searchText: 'test search',
+      batchNumber: component.batchNumber,
+      quizCategoryId: 5,
+      quizDifficultyLevelId: null,
+      browseQuizzesSorting: null,
+      browseQuizzesFilterByType: null,
+      filterRanges: component.filtersForm.value.filterRanges,
+      tagIds: [10, 20],
+    };
+
+    component.fetchQuizzesList();
+
+    const lastCallArg = browseQuizzesServiceMock.browseQuizzes.mock.calls.slice(-1)[0][0];
+
+    expect(lastCallArg).toEqual(expectedPayload);
+  });
+
+  it('should initialize form with correct default values including empty arrays and nulls', () => {
+    expect(component.filtersForm.value.quizCategoryId).toBeNull();
+    expect(component.filtersForm.value.quizDifficultyLevelId).toBeNull();
+    expect(component.filtersForm.value.browseQuizzesSorting).toBeNull();
+    expect(component.filtersForm.value.browseQuizzesFilterByType).toBeNull();
+    expect(component.filtersForm.value.tagIds).toEqual([]);
+  });
+
+  it('should initialize form with correct default values including empty arrays and nulls', () => {
+    expect(component.filtersForm.value.quizCategoryId).toBeNull();
+    expect(component.filtersForm.value.quizDifficultyLevelId).toBeNull();
+    expect(component.filtersForm.value.browseQuizzesSorting).toBeNull();
+    expect(component.filtersForm.value.browseQuizzesFilterByType).toBeNull();
+    expect(component.filtersForm.value.tagIds).toEqual([]); // empty array initially
+  });
+  it('clearFilters sets tagIds to null, not empty array', () => {
+    component.filtersForm.patchValue({ tagIds: [1, 2, 3] });
+
+    component.clearFilters();
+
+    expect(component.filtersForm.value.tagIds).toBeNull(); // Important to expect null here
+  });
+
+  it('tagClosed sets tagIds to null when last tag is removed', () => {
+    component.filtersForm.patchValue({ tagIds: [1] });
+    component.tagClosed({ id: '1', label: 'Tag1' });
+
+    expect(component.filtersForm.value.tagIds).toBeNull(); // This should pass if your component sets it properly
+  });
+
+  it('fetchQuizzesList payload sets tagIds to null if empty array in form', () => {
+    component.filtersForm.patchValue({ tagIds: [] });
+    component.searchControl.setValue('test');
+    component.batchNumber = 1;
+    component.currentTabId.set('featured');
+
+    component.fetchQuizzesList();
+
+    const lastCallArg = browseQuizzesServiceMock.browseQuizzes.mock.calls.slice(-1)[0][0];
+    expect(lastCallArg.tagIds).toBeNull();
   });
 });

--- a/src/app/pages/user/browse-quizzes/browse-quizzes.component.ts
+++ b/src/app/pages/user/browse-quizzes/browse-quizzes.component.ts
@@ -1,9 +1,253 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { Subject, debounceTime, distinctUntilChanged, forkJoin, takeUntil } from 'rxjs';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSliderModule } from '@angular/material/slider';
+import { TabComponent } from '../../../shared/components/tab/tab.component';
+import { SearchInputComponent } from '../../../shared/components/search-input/search-input.component';
+import { OutlineButtonComponent } from '../../../shared/components/outline-button/outline-button.component';
+import { FilledButtonComponent } from '../../../shared/components/filled-button/filled-button.component';
+import { TagComponent } from '../../../shared/components/tag/tag.component';
+import {
+  clearFilterButtonConfig,
+  loadMoreButtonConfig,
+  searchInputConfig,
+  showFilterButtonConfig,
+} from './configs/browse-quizzes.config';
+import { CommonListDropDown } from '../../../shared/interfaces/common-dropdown.interface';
+import { TagInputConfig } from '../../../shared/interfaces/tag-component.interface';
+import { quizTabConfig } from './configs/browse-quizzes-tab.config';
+import { BrowseQuizzesService } from '../../../services/user/browse-quizzes/browse-quizzes.service';
+import { BrowseQuizzesRequest, QuizCardConfig } from './interfaces/browsr-quiz-request.interface';
+import {
+  mapDropdownToTags,
+  mapQuizToCardConfig,
+  mapSortingEnumToDropdown,
+  tabToTypeMap,
+  updateTabLabels,
+} from './browse-quizzes.mapper';
+import { DropDownType } from '../../../shared/enums/dropdown-types.enum';
+import { DropdownService } from '../../../shared/service/dropdown/dropdown.service';
+import { debounceTimeValue, platformMessages } from '../../../utils/constants';
+import { SnackbarService } from '../../../shared/service/snackbar/snackbar.service';
 
 @Component({
   selector: 'app-browse-quizzes',
-  imports: [],
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    TabComponent,
+    SearchInputComponent,
+    OutlineButtonComponent,
+    FilledButtonComponent,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatSliderModule,
+    TagComponent,
+  ],
   templateUrl: './browse-quizzes.component.html',
   styleUrl: './browse-quizzes.component.scss',
 })
-export class BrowseQuizzesComponent {}
+export class BrowseQuizzesComponent implements OnInit {
+  tabs = quizTabConfig;
+  searchInputConfig = searchInputConfig;
+  showFilterBtn = showFilterButtonConfig;
+  clearFilterBtn = clearFilterButtonConfig;
+  loadMoreBtnConfig = loadMoreButtonConfig;
+  tabToTypeMap = tabToTypeMap;
+
+  selectedTab = signal(0);
+  currentTabId = signal<string>('featured');
+  tabCounts = signal({
+    featured: 0,
+    allQuizzes: 0,
+    free: 0,
+    premium: 0,
+  });
+
+  batchNumber = 1;
+  hasMoreResults = true;
+  showFiltersPanel = false;
+  searchControl = new FormControl<string | null>(null);
+
+  quizzes: QuizCardConfig[] = [];
+  allTags: TagInputConfig[] = [];
+  categoryList: CommonListDropDown[] = [];
+  difficultyList: CommonListDropDown[] = [];
+  typeList: CommonListDropDown[] = [];
+
+  private readonly fb = inject(FormBuilder);
+  private readonly service = inject(BrowseQuizzesService);
+  private readonly dropdownService = inject(DropdownService);
+  private readonly snackbarService = inject(SnackbarService);
+
+  private readonly searchSubject$ = new Subject<string>();
+  private readonly destroy$ = new Subject<void>();
+
+  filtersForm: FormGroup = this.fb.group({
+    quizCategoryId: [null],
+    quizDifficultyLevelId: [null],
+    browseQuizzesSorting: [null],
+    browseQuizzesFilterByType: [null],
+    filterRanges: this.fb.group({
+      minPrice: [0],
+      maxPrice: [1000],
+      minRating: [0],
+      maxRating: [5],
+      minTotalTime: [2],
+      maxTotalTime: [180],
+    }),
+    tagIds: [[]],
+  });
+
+  ngOnInit(): void {
+    this.fetchQuizzesList();
+
+    this.searchSubject$
+      .pipe(debounceTime(debounceTimeValue), distinctUntilChanged(), takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.batchNumber = 1;
+        this.fetchQuizzesList(true);
+      });
+
+    this.loadDropdowns();
+  }
+
+  loadDropdowns(): void {
+    forkJoin({
+      categories: this.dropdownService.getDropdownData(DropDownType.QuizCategory),
+      difficulties: this.dropdownService.getDropdownData(DropDownType.QuizDifficulty),
+      tags: this.dropdownService.getDropdownData(DropDownType.QuizTag),
+    })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(({ categories, difficulties, tags }) => {
+        this.categoryList = categories;
+        this.difficultyList = difficulties;
+        this.typeList = mapSortingEnumToDropdown();
+        this.allTags = mapDropdownToTags(tags);
+      });
+  }
+
+  searchInputChange(value: string): void {
+    this.searchSubject$.next(value);
+  }
+
+  switchToTab(index: number) {
+    this.selectedTab.set(index);
+    this.currentTabId.set(this.tabs[index].id);
+
+    // type filter for tabs
+    const typeFilter = this.tabToTypeMap[this.currentTabId()];
+    this.filtersForm.patchValue({ browseQuizzesFilterByType: typeFilter ?? null });
+
+    this.batchNumber = 1;
+    this.fetchQuizzesList(true);
+  }
+
+  fetchQuizzesList(reset: boolean = false) {
+    const tagIds = this.filtersForm.value.tagIds?.length ? this.filtersForm.value.tagIds : null;
+
+    // type from current tab
+    const typeFilter = this.tabToTypeMap[this.currentTabId()];
+
+    const payload: BrowseQuizzesRequest = {
+      searchText: this.searchControl.value ?? '',
+      batchNumber: this.batchNumber,
+      ...this.filtersForm.value,
+      tagIds,
+      browseQuizzesFilterByType: typeFilter ?? this.filtersForm.value.browseQuizzesFilterByType,
+    };
+
+    this.service
+      .browseQuizzes(payload)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          if (res.result && res.data) {
+            const records = res.data.quizzes ?? [];
+            const mapped = records.map(mapQuizToCardConfig);
+
+            this.quizzes = reset ? mapped : [...this.quizzes, ...mapped];
+            this.hasMoreResults = res.data.hasMore;
+
+            this.tabCounts.set({
+              featured: res.data.totalFeatured ?? 0,
+              allQuizzes: res.data.totalAll ?? 0,
+              free: res.data.totalFree ?? 0,
+              premium: res.data.totalPremium ?? 0,
+            });
+
+            this.tabs = updateTabLabels(this.tabCounts());
+          }
+        },
+        error: () => {
+          this.snackbarService.showError(
+            platformMessages.errorTitle,
+            platformMessages.failedLoadQuesPreview,
+          );
+        },
+      });
+  }
+
+  loadMore() {
+    this.batchNumber++;
+    this.fetchQuizzesList();
+  }
+
+  filterChange() {
+    this.batchNumber = 1;
+    this.fetchQuizzesList(true);
+  }
+
+  toggleFilters() {
+    this.showFiltersPanel = !this.showFiltersPanel;
+  }
+
+  clearFilters() {
+    this.filtersForm.reset({
+      quizCategoryId: null,
+      quizDifficultyLevelId: null,
+      browseQuizzesFilterByType: null,
+      filterRanges: {
+        minPrice: 0,
+        maxPrice: 1000,
+        minRating: 0,
+        maxRating: 5,
+        minTotalTime: 2,
+        maxTotalTime: 180,
+      },
+      tagIds: null,
+    });
+    this.searchControl.setValue(null);
+    this.allTags = this.allTags.map((tag) => ({
+      ...tag,
+      isSelected: false,
+    }));
+    this.batchNumber = 1;
+    this.fetchQuizzesList(true);
+  }
+
+  tagSelected(event: { id: string; label: string; isSelected: boolean }): void {
+    const currentTags = this.filtersForm.value.tagIds || [];
+    if (event.isSelected) {
+      this.filtersForm.patchValue({ tagIds: [...currentTags, Number(event.id)] });
+    }
+    this.filterChange();
+  }
+
+  tagClosed(event: { id: string; label: string }): void {
+    const updatedTags = (this.filtersForm.value.tagIds || []).filter(
+      (tagId: number) => tagId !== Number(event.id),
+    );
+    this.filtersForm.patchValue({ tagIds: updatedTags.length ? updatedTags : null });
+    this.filterChange();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/src/app/pages/user/browse-quizzes/browse-quizzes.mapper.spec.ts
+++ b/src/app/pages/user/browse-quizzes/browse-quizzes.mapper.spec.ts
@@ -1,0 +1,177 @@
+import {
+  mapQuizToCardConfig,
+  mapSortingEnumToDropdown,
+  mapDropdownToTags,
+  getTabCount,
+  updateTabLabels,
+  tabToTypeMap,
+} from './browse-quizzes.mapper';
+import { BrowseQuizResponse } from './interfaces/browse-quiz-response.interface';
+import {
+  BrowseQuizzesSorting,
+  BrowseQuizzesFilterByType,
+} from '../../../shared/enums/browse-quiz.enum';
+import { QuizCardConfig } from './interfaces/browsr-quiz-request.interface';
+
+describe('BrowseQuizzes Mapper', () => {
+  describe('mapQuizToCardConfig', () => {
+    it('should map API quiz response to QuizCardConfig', () => {
+      const apiQuiz: BrowseQuizResponse = {
+        id: 1,
+        name: 'Test Quiz',
+        description: 'Quiz description',
+        categoryName: 'Science',
+        difficultyLevel: 'Easy',
+        isPaid: true,
+        price: 50,
+        tags: ['Physics', 'Math'],
+        totalTime: 30,
+        totalQuestions: 10,
+        totalParticipates: 100,
+        rating: 4.5,
+        isFeatured: true,
+        isAttempted: false,
+      };
+
+      const card: QuizCardConfig = mapQuizToCardConfig(apiQuiz);
+
+      expect(card.title).toBe(apiQuiz.name);
+      expect(card.description).toBe(apiQuiz.description);
+      expect(card.category.label).toBe('Science');
+      expect(card.difficulty.label).toBe('Easy');
+      expect(card.priceTag?.label).toBe('₹ 50');
+      expect(card.tags?.length).toBe(2);
+      expect(card.duration).toBe('30m');
+      expect(card.questions).toBe(10);
+      expect(card.participants).toBe(100);
+      expect(card.rating).toBe(4.5);
+      expect(card.isFeatured).toBe(true);
+      expect(card.isPaid).toBe(true);
+      expect(card.buttonConfig.label).toBe('Play ₹50');
+    });
+
+    it('should handle free quiz without priceTag', () => {
+      const apiQuiz: BrowseQuizResponse = {
+        id: 2,
+        name: 'Free Quiz',
+        description: 'Free quiz',
+        categoryName: 'Math',
+        difficultyLevel: 'Medium',
+        isPaid: false,
+        price: 0,
+        tags: [],
+        totalTime: 20,
+        totalQuestions: 5,
+        totalParticipates: 50,
+        rating: 4,
+        isFeatured: false,
+        isAttempted: false,
+      };
+
+      const card = mapQuizToCardConfig(apiQuiz);
+      expect(card.priceTag).toBeUndefined();
+      expect(card.buttonConfig.label).toBe('Play Free');
+    });
+
+    it('should set button label to "Show Result" if quiz is attempted', () => {
+      const apiQuiz: BrowseQuizResponse = {
+        id: 3,
+        name: 'Attempted Quiz',
+        description: 'Already attempted quiz',
+        categoryName: 'History',
+        difficultyLevel: 'Hard',
+        isPaid: true,
+        price: 100,
+        tags: ['Ancient', 'Modern'],
+        totalTime: 40,
+        totalQuestions: 15,
+        totalParticipates: 200,
+        rating: 4.8,
+        isFeatured: false,
+        isAttempted: true,
+      };
+
+      const card = mapQuizToCardConfig(apiQuiz);
+      expect(card.buttonConfig.label).toBe('Show Result');
+      expect(card.buttonConfig.matIcon).toBe('visibility');
+    });
+  });
+
+  describe('mapSortingEnumToDropdown', () => {
+    it('should map sorting enum to dropdown array', () => {
+      const dropdown = mapSortingEnumToDropdown();
+      expect(dropdown).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: BrowseQuizzesSorting.MostPopular, name: 'Most Popular' }),
+          expect.objectContaining({ id: BrowseQuizzesSorting.HighestRated, name: 'Highest Rated' }),
+          expect.objectContaining({ id: BrowseQuizzesSorting.Newest, name: 'Newest' }),
+          expect.objectContaining({
+            id: BrowseQuizzesSorting.PriceLowToHigh,
+            name: 'Price Low To High',
+          }),
+        ]),
+      );
+    });
+  });
+
+  describe('mapDropdownToTags', () => {
+    it('should map dropdowns to TagInputConfig', () => {
+      const dropdowns = [
+        { id: 1, name: 'Science' },
+        { id: 2, name: 'Math' },
+      ];
+      const tags = mapDropdownToTags(dropdowns);
+      expect(tags.length).toBe(2);
+      expect(tags[0].label).toBe('Science');
+      expect(tags[1].label).toBe('Math');
+    });
+  });
+
+  describe('getTabCount', () => {
+    const counts = { featured: 5, allQuizzes: 10, free: 3, premium: 2 };
+
+    it('should return correct count for each tab', () => {
+      expect(getTabCount('featured', counts)).toBe(5);
+      expect(getTabCount('all-quizzes', counts)).toBe(10);
+      expect(getTabCount('free', counts)).toBe(3);
+      expect(getTabCount('premium', counts)).toBe(2);
+    });
+
+    it('should return 0 for unknown tab', () => {
+      expect(getTabCount('unknown', counts)).toBe(0);
+    });
+  });
+
+  describe('updateTabLabels', () => {
+    it('should update tab labels with counts', () => {
+      const counts = {
+        featured: 0,
+        'all-quizzes': 10,
+        free: 3,
+        premium: 2,
+      };
+
+      const updatedTabs = updateTabLabels({
+        featured: counts['featured'],
+        allQuizzes: counts['all-quizzes'],
+        free: counts['free'],
+        premium: counts['premium'],
+      });
+
+      updatedTabs.forEach((updatedTab) => {
+        const originalLabel = updatedTab.label.split(' (')[0];
+        const expectedCount = counts[updatedTab.id as keyof typeof counts] ?? 0;
+        expect(updatedTab.label).toBe(`${originalLabel} (${expectedCount})`);
+      });
+    });
+  });
+
+  describe('tabToTypeMap', () => {
+    it('should have correct mapping for tabs', () => {
+      expect(tabToTypeMap['featured']).toBe(BrowseQuizzesFilterByType.Featured);
+      expect(tabToTypeMap['all-quizzes']).toBeNull();
+      expect(tabToTypeMap['free']).toBe(BrowseQuizzesFilterByType.Free);
+      expect(tabToTypeMap['premium']).toBe(BrowseQuizzesFilterByType.Premium);
+    });
+  });
+});

--- a/src/app/pages/user/browse-quizzes/browse-quizzes.mapper.ts
+++ b/src/app/pages/user/browse-quizzes/browse-quizzes.mapper.ts
@@ -1,0 +1,138 @@
+import {
+  BrowseQuizzesSorting,
+  BrowseQuizzesFilterByType,
+} from '../../../shared/enums/browse-quiz.enum';
+import { CommonListDropDown } from '../../../shared/interfaces/common-dropdown.interface';
+import { DropDownData } from '../../../shared/interfaces/drop-down-data.interface';
+import { TagInputConfig } from '../../../shared/interfaces/tag-component.interface';
+import { defaultTagConfig } from './configs/browse-quizzes.config';
+import { BrowseQuizResponse } from './interfaces/browse-quiz-response.interface';
+import { quizTabConfig } from './configs/browse-quizzes-tab.config';
+import { QuizCardConfig } from './interfaces/browsr-quiz-request.interface';
+
+export function mapQuizToCardConfig(apiQuiz: BrowseQuizResponse): QuizCardConfig {
+  return {
+    id: apiQuiz.id,
+    title: apiQuiz.name,
+    description: apiQuiz.description,
+    category: {
+      id: apiQuiz.categoryName.toLowerCase(),
+      label: apiQuiz.categoryName,
+      type: 'static',
+      isSelected: false,
+      hasBorder: true,
+      backgroundColor: 'lightYellow',
+      textColor: 'yellow',
+    },
+    difficulty: {
+      id: apiQuiz.difficultyLevel.toLowerCase(),
+      label: apiQuiz.difficultyLevel,
+      type: 'static',
+      isSelected: false,
+      hasBorder: true,
+      backgroundColor: 'lightWhite',
+      textColor: 'black',
+    },
+    priceTag: apiQuiz.isPaid
+      ? {
+          id: `price-${apiQuiz.id}`,
+          label: `₹ ${apiQuiz.price}`,
+          type: 'static',
+          isSelected: false,
+          hasBorder: true,
+          backgroundColor: 'lightGreen',
+          textColor: 'green',
+        }
+      : undefined,
+    tags: (apiQuiz.tags || [])
+      .filter((tag) => tag !== null)
+      .map((tag, i) => ({
+        id: `${apiQuiz.id}-tag-${i}`,
+        label: tag,
+        type: 'static',
+        isSelected: false,
+        hasBorder: false,
+        backgroundColor: 'lightPurple',
+        textColor: 'purple',
+      })),
+    duration: `${apiQuiz.totalTime}m`,
+    questions: apiQuiz.totalQuestions,
+    participants: apiQuiz.totalParticipates,
+    rating: apiQuiz.rating,
+    isFeatured: apiQuiz.isFeatured,
+    isPaid: apiQuiz.isPaid,
+    isAttempted: apiQuiz.isAttempted,
+    buttonConfig: apiQuiz.isAttempted
+      ? {
+          label: 'Show Result',
+          matIcon: 'visibility',
+          iconFontSet: 'material-icons-outlined',
+          variant: 'secondary',
+          fontWeight: 600,
+        }
+      : {
+          label: apiQuiz.isPaid ? `Play ₹${apiQuiz.price}` : 'Play Free',
+          matIcon: 'play_arrow',
+          iconFontSet: 'material-icons-outlined',
+          variant: 'secondary',
+          fontWeight: 600,
+        },
+  };
+}
+
+export function mapSortingEnumToDropdown(): DropDownData[] {
+  return Object.keys(BrowseQuizzesSorting)
+    .filter((key) => isNaN(Number(key)))
+    .map((key) => ({
+      id: BrowseQuizzesSorting[key as keyof typeof BrowseQuizzesSorting],
+      name: key.replace(/([A-Z])/g, ' $1').trim(),
+    }));
+}
+
+export function mapDropdownToTags(dropdowns: CommonListDropDown[]): TagInputConfig[] {
+  return dropdowns.map((drop) => ({
+    ...defaultTagConfig,
+    id: drop.id.toString(),
+    label: drop.name,
+  }));
+}
+
+export function getTabCount(
+  tabId: string,
+  tabCounts: { featured: number; allQuizzes: number; free: number; premium: number },
+): number {
+  switch (tabId) {
+    case 'featured':
+      return tabCounts.featured;
+    case 'all-quizzes':
+      return tabCounts.allQuizzes;
+    case 'free':
+      return tabCounts.free;
+    case 'premium':
+      return tabCounts.premium;
+    default:
+      return 0;
+  }
+}
+
+export function updateTabLabels(tabCounts: {
+  featured: number;
+  allQuizzes: number;
+  free: number;
+  premium: number;
+}) {
+  return quizTabConfig.map((tab) => {
+    const count = getTabCount(tab.id, tabCounts);
+    return {
+      ...tab,
+      label: `${tab.label.split(' (')[0]} (${count})`,
+    };
+  });
+}
+
+export const tabToTypeMap: Record<string, BrowseQuizzesFilterByType | null> = {
+  featured: BrowseQuizzesFilterByType.Featured,
+  'all-quizzes': null,
+  free: BrowseQuizzesFilterByType.Free,
+  premium: BrowseQuizzesFilterByType.Premium,
+};

--- a/src/app/pages/user/browse-quizzes/components/quiz-card/quiz-card.component.html
+++ b/src/app/pages/user/browse-quizzes/components/quiz-card/quiz-card.component.html
@@ -1,1 +1,73 @@
-<p>quiz-card works!</p>
+<div class="quiz-card" [ngClass]="cardStyle()">
+  <!-- Title -->
+  <div class="quiz-title">
+    <h3>
+      <span>{{ cardConfig.title }}</span>
+      @if (cardConfig.isFeatured) {
+        <mat-icon fontSet="material-icons-outlined" class="mat-icon featured-icon">
+          diamond
+        </mat-icon>
+      }
+      @if (cardConfig.isPaid) {
+        <mat-icon fontSet="material-icons-outlined" class="mat-icon lock-icon"> lock </mat-icon>
+      } @else {
+        <mat-icon fontSet="material-icons-outlined" class="mat-icon lock-open-icon">
+          lock_open_right
+        </mat-icon>
+      }
+    </h3>
+  </div>
+
+  <p>{{ cardConfig.description }}</p>
+
+  <!-- Category & Price tags -->
+  <div class="category-tags">
+    @if (cardConfig.category) {
+      <app-tag [tagConfig]="cardConfig.category"></app-tag>
+    }
+    @if (cardConfig.difficulty) {
+      <app-tag [tagConfig]="cardConfig.difficulty"></app-tag>
+    }
+    @if (cardConfig.priceTag) {
+      <app-tag [tagConfig]="cardConfig.priceTag"></app-tag>
+    }
+  </div>
+
+  <!-- Quiz Tags -->
+  <div class="tags">
+    @for (tag of displayTags(); track tag.id) {
+      <app-tag [tagConfig]="tag"></app-tag>
+    }
+  </div>
+
+  <!-- Meta info -->
+  <div class="meta">
+    <div class="meta-container">
+      <div class="meta-info">
+        <mat-icon fontSet="material-icons-outlined" class="mat-icon">schedule</mat-icon>
+        <span>{{ cardConfig.duration }}</span>
+      </div>
+      <div class="meta-info">
+        <mat-icon fontSet="material-icons-outlined" class="mat-icon">question_mark</mat-icon>
+        <span>{{ cardConfig.questions }} questions</span>
+      </div>
+    </div>
+    <div class="meta-container">
+      <div class="meta-info">
+        <mat-icon fontSet="material-icons-outlined" class="mat-icon">group</mat-icon>
+        <span>{{ cardConfig.participants }}</span>
+      </div>
+      <div class="meta-info">
+        <mat-icon fontSet="material-icons-outlined" class="mat-icon star">star_rate</mat-icon>
+        <span>{{ cardConfig.rating }}</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="quiz-play-btn">
+    <app-filled-button
+      [filledButtonConfig]="cardConfig.buttonConfig"
+      (click)="quizBtnClick()"
+    ></app-filled-button>
+  </div>
+</div>

--- a/src/app/pages/user/browse-quizzes/components/quiz-card/quiz-card.component.spec.ts
+++ b/src/app/pages/user/browse-quizzes/components/quiz-card/quiz-card.component.spec.ts
@@ -1,6 +1,61 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { QuizCardComponent } from './quiz-card.component';
+import { QuizListComponent } from '../quiz-list/quiz-list.component';
+import { TagInputConfig } from '../../../../../shared/interfaces/tag-component.interface';
+import { ButtonConfig } from '../../../../../shared/interfaces/button-config.interface';
+import { Router } from '@angular/router';
+import { Navigations } from '../../../../../shared/enums/navigation';
+
+class MockQuizListComponent {
+  cardStyle = jest.fn().mockReturnValue('featured');
+}
+
+const mockTags: TagInputConfig[] = [
+  {
+    id: '1',
+    label: 'Math',
+    type: 'static',
+    isSelected: false,
+    hasBorder: true,
+    backgroundColor: 'lightWhite',
+    textColor: 'black',
+  },
+  {
+    id: '2',
+    label: 'Science',
+    type: 'static',
+    isSelected: false,
+    hasBorder: true,
+    backgroundColor: 'lightWhite',
+    textColor: 'black',
+  },
+  {
+    id: '3',
+    label: 'GK',
+    type: 'static',
+    isSelected: false,
+    hasBorder: true,
+    backgroundColor: 'lightWhite',
+    textColor: 'black',
+  },
+  {
+    id: '4',
+    label: 'Extra',
+    type: 'static',
+    isSelected: false,
+    hasBorder: true,
+    backgroundColor: 'lightWhite',
+    textColor: 'black',
+  },
+];
+
+const mockButtonConfig: ButtonConfig = {
+  label: 'Play Free',
+  matIcon: 'play_arrow',
+  iconFontSet: 'material-icons-outlined',
+  variant: 'secondary',
+  fontWeight: 600,
+};
 
 describe('QuizCardComponent', () => {
   let component: QuizCardComponent;
@@ -9,14 +64,128 @@ describe('QuizCardComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [QuizCardComponent],
+      providers: [{ provide: QuizListComponent, useClass: MockQuizListComponent }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(QuizCardComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create the component', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should expose full tags if <= 3', () => {
+    component.cardConfig = {
+      id: 1,
+      title: 'Quiz 1',
+      description: 'Desc',
+      category: mockTags[0],
+      difficulty: mockTags[1],
+      duration: '20m',
+      questions: 10,
+      participants: 100,
+      rating: 4.5,
+      isFeatured: true,
+      isPaid: false,
+      isAttempted: false,
+      buttonConfig: mockButtonConfig,
+      tags: mockTags.slice(0, 2),
+    };
+
+    fixture.detectChanges();
+
+    expect(component.displayTags().length).toBe(2);
+    expect(component.displayTags().some((t) => t.label.includes('+'))).toBe(false);
+  });
+
+  it('should add "+N more" tag if > 3 tags', () => {
+    component.cardConfig = {
+      id: 2,
+      title: 'Quiz 2',
+      description: 'Desc',
+      category: mockTags[0],
+      difficulty: mockTags[1],
+      duration: '20m',
+      questions: 10,
+      participants: 100,
+      rating: 4.5,
+      isFeatured: true,
+      isPaid: false,
+      isAttempted: false,
+      buttonConfig: mockButtonConfig,
+      tags: mockTags,
+    };
+
+    fixture.detectChanges();
+
+    const displayTags = component.displayTags();
+    expect(displayTags.length).toBe(4);
+    expect(displayTags[3].label).toBe('+1 more');
+  });
+
+  it('should get cardStyle from parent', () => {
+    expect(component.cardStyle()).toBe('featured');
+  });
+
+  it('should navigate to quiz result if quiz is attempted', () => {
+    const router = TestBed.inject(Router);
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    component.cardConfig = {
+      id: 10,
+      title: 'Attempted Quiz',
+      description: 'Desc',
+      category: mockTags[0],
+      difficulty: mockTags[1],
+      duration: '20m',
+      questions: 10,
+      participants: 100,
+      rating: 4.5,
+      isFeatured: false,
+      isPaid: true,
+      isAttempted: true,
+      buttonConfig: mockButtonConfig,
+      tags: [],
+    };
+
+    component.quizBtnClick();
+
+    expect(navigateSpy).toHaveBeenCalledWith([Navigations.QuizList, Navigations.Quizzes]);
+  });
+
+  it('should navigate to quiz instruction if quiz is not attempted', () => {
+    const router = TestBed.inject(Router);
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    const quizId = 20;
+    const encodedId = btoa(quizId.toString());
+
+    component.cardConfig = {
+      id: quizId,
+      title: 'New Quiz',
+      description: 'Desc',
+      category: mockTags[0],
+      difficulty: mockTags[1],
+      duration: '20m',
+      questions: 10,
+      participants: 100,
+      rating: 4.5,
+      isFeatured: false,
+      isPaid: false,
+      isAttempted: false,
+      buttonConfig: mockButtonConfig,
+      tags: [],
+    };
+
+    component.quizBtnClick();
+
+    expect(navigateSpy).toHaveBeenCalledWith([
+      Navigations.User,
+      Navigations.QuizList,
+      Navigations.BrowseQuizzes,
+      Navigations.QuizInstruction,
+      encodedId,
+    ]);
   });
 });

--- a/src/app/pages/user/browse-quizzes/components/quiz-card/quiz-card.component.ts
+++ b/src/app/pages/user/browse-quizzes/components/quiz-card/quiz-card.component.ts
@@ -1,9 +1,64 @@
-import { Component } from '@angular/core';
+import { Component, computed, inject, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TagComponent } from '../../../../../shared/components/tag/tag.component';
+import { FilledButtonComponent } from '../../../../../shared/components/filled-button/filled-button.component';
+import { MatIconModule } from '@angular/material/icon';
+import { TagInputConfig } from '../../../../../shared/interfaces/tag-component.interface';
+import { QuizListComponent } from '../quiz-list/quiz-list.component';
+import { Router } from '@angular/router';
+import { Navigations } from '../../../../../shared/enums/navigation';
+import { QuizCardConfig } from '../../interfaces/browsr-quiz-request.interface';
 
 @Component({
   selector: 'app-quiz-card',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, TagComponent, FilledButtonComponent, MatIconModule],
   templateUrl: './quiz-card.component.html',
-  styleUrl: './quiz-card.component.scss',
+  styleUrls: ['./quiz-card.component.scss'],
 })
-export class QuizCardComponent {}
+export class QuizCardComponent {
+  private readonly quizList = inject(QuizListComponent);
+  private readonly router = inject(Router);
+
+  cardStyle = computed(() => this.quizList.cardStyle());
+
+  @Input() cardConfig!: QuizCardConfig;
+
+  displayTags = computed<TagInputConfig[]>(() => {
+    const tags = this.cardConfig?.tags ?? [];
+    if (tags.length <= 3) {
+      return tags;
+    }
+
+    return [
+      ...tags.slice(0, 3),
+      {
+        id: 'extra',
+        label: `+${tags.length - 3} more`,
+        type: 'static',
+        isSelected: false,
+        hasBorder: false,
+        backgroundColor: 'lightPurple',
+        textColor: 'black',
+      } as TagInputConfig,
+    ];
+  });
+
+  quizBtnClick() {
+    const encodedId = btoa(this.cardConfig.id.toString());
+
+    if (this.cardConfig.isAttempted) {
+      // redirect to quiz result
+      this.router.navigate([Navigations.QuizList, Navigations.Quizzes]);
+    } else {
+      // redirect to quiz play
+      this.router.navigate([
+        Navigations.User,
+        Navigations.QuizList,
+        Navigations.BrowseQuizzes,
+        Navigations.QuizInstruction,
+        encodedId,
+      ]);
+    }
+  }
+}

--- a/src/app/pages/user/browse-quizzes/components/quiz-list/quiz-list.component.html
+++ b/src/app/pages/user/browse-quizzes/components/quiz-list/quiz-list.component.html
@@ -1,1 +1,9 @@
-<p>quiz-list works!</p>
+<div class="quiz-list">
+  @for (quiz of quizzes; track quiz.title) {
+    <app-quiz-card [cardConfig]="quiz"></app-quiz-card>
+  } @empty {
+    <div class="empty-card">
+      <p>No quizzes found.</p>
+    </div>
+  }
+</div>

--- a/src/app/pages/user/browse-quizzes/components/quiz-list/quiz-list.component.spec.ts
+++ b/src/app/pages/user/browse-quizzes/components/quiz-list/quiz-list.component.spec.ts
@@ -1,14 +1,63 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { QuizListComponent } from './quiz-list.component';
+import { QuizCardComponent } from '../quiz-card/quiz-card.component';
+import { BrowseQuizzesComponent } from '../../browse-quizzes.component';
+import { signal } from '@angular/core';
+import { QuizCardConfig } from '../../interfaces/browsr-quiz-request.interface';
 
 describe('QuizListComponent', () => {
   let component: QuizListComponent;
   let fixture: ComponentFixture<QuizListComponent>;
 
+  const mockQuizzes: QuizCardConfig[] = [
+    {
+      id: 1,
+      title: 'Quiz 1',
+      description: 'Test quiz 1',
+      category: {
+        id: '1',
+        label: 'Math',
+        type: 'static',
+        isSelected: false,
+        hasBorder: true,
+        backgroundColor: 'lightYellow',
+        textColor: 'yellow',
+      },
+      difficulty: {
+        id: 'easy',
+        label: 'Easy',
+        type: 'static',
+        isSelected: false,
+        hasBorder: true,
+        backgroundColor: 'lightWhite',
+        textColor: 'black',
+      },
+      duration: '10m',
+      questions: 5,
+      participants: 20,
+      rating: 4.5,
+      isFeatured: false,
+      isPaid: false,
+      isAttempted: false,
+      buttonConfig: {
+        label: 'Play Free',
+        matIcon: 'play_arrow',
+        iconFontSet: 'material-icons-outlined',
+        variant: 'secondary',
+        fontWeight: 600,
+      },
+    },
+  ];
+
+  class MockBrowseQuizzesComponent {
+    quizzes = mockQuizzes;
+    currentTabId = signal('free');
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [QuizListComponent],
+      imports: [QuizListComponent, QuizCardComponent],
+      providers: [{ provide: BrowseQuizzesComponent, useClass: MockBrowseQuizzesComponent }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(QuizListComponent);
@@ -16,7 +65,26 @@ describe('QuizListComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create the component', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should return quizzes from the parent component', () => {
+    expect(component.quizzes).toEqual(mockQuizzes);
+  });
+
+  it('should compute the correct tabId from parent signal', () => {
+    expect(component.tabId()).toBe('free');
+  });
+
+  it('should compute the correct card style for non-featured tab', () => {
+    expect(component.cardStyle()).toBe('normal');
+  });
+
+  it('should compute "featured" card style when tabId is "featured"', () => {
+    const parent = TestBed.inject(BrowseQuizzesComponent) as MockBrowseQuizzesComponent;
+    parent.currentTabId.set('featured');
+    fixture.detectChanges();
+    expect(component.cardStyle()).toBe('featured');
   });
 });

--- a/src/app/pages/user/browse-quizzes/components/quiz-list/quiz-list.component.ts
+++ b/src/app/pages/user/browse-quizzes/components/quiz-list/quiz-list.component.ts
@@ -1,9 +1,24 @@
-import { Component } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { QuizCardComponent } from '../quiz-card/quiz-card.component';
+import { BrowseQuizzesComponent } from '../../browse-quizzes.component';
+import { QuizCardConfig } from '../../interfaces/browsr-quiz-request.interface';
 
 @Component({
   selector: 'app-quiz-list',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, QuizCardComponent],
   templateUrl: './quiz-list.component.html',
   styleUrl: './quiz-list.component.scss',
 })
-export class QuizListComponent {}
+export class QuizListComponent {
+  private readonly parent = inject(BrowseQuizzesComponent);
+
+  tabId = computed(() => this.parent.currentTabId());
+
+  cardStyle = computed(() => (this.tabId() === 'featured' ? 'featured' : 'normal'));
+
+  get quizzes(): QuizCardConfig[] {
+    return this.parent.quizzes;
+  }
+}

--- a/src/app/services/user/browse-quizzes/browse-quizzes.service.spec.ts
+++ b/src/app/services/user/browse-quizzes/browse-quizzes.service.spec.ts
@@ -1,16 +1,72 @@
 import { TestBed } from '@angular/core/testing';
-
+import { HttpClient } from '@angular/common/http';
+import { of } from 'rxjs';
 import { BrowseQuizzesService } from './browse-quizzes.service';
+import { environment } from '../../../../environments/environment.dev';
+import { EndPoints } from '../../../shared/enums/end-point.enum';
+import { BrowseQuizzesRequest } from '../../../pages/user/browse-quizzes/interfaces/browsr-quiz-request.interface';
+import { ApiResponse } from '../../../shared/interfaces/api-response.interface';
+import { BrowseQuizzesApiResponse } from '../../../pages/user/browse-quizzes/interfaces/browse-quiz-response.interface';
 
 describe('BrowseQuizzesService', () => {
   let service: BrowseQuizzesService;
+  let httpMock: jest.Mocked<HttpClient>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    const httpClientMock = {
+      post: jest.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [BrowseQuizzesService, { provide: HttpClient, useValue: httpClientMock }],
+    });
+
     service = TestBed.inject(BrowseQuizzesService);
+    httpMock = TestBed.inject(HttpClient) as jest.Mocked<HttpClient>;
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('should send POST request to correct URL with given payload', (done) => {
+    const mockPayload: BrowseQuizzesRequest = {
+      searchText: 'test',
+      batchNumber: 1,
+      quizCategoryId: null,
+      quizDifficultyLevelId: null,
+      browseQuizzesSorting: null,
+      browseQuizzesFilterByType: null,
+      filterRanges: {
+        minPrice: 0,
+        maxPrice: 1000,
+        minRating: 0,
+        maxRating: 5,
+        minTotalTime: 2,
+        maxTotalTime: 180,
+      },
+      tags: null,
+    };
+
+    const mockResponse: ApiResponse<BrowseQuizzesApiResponse> = {
+      result: true,
+      statusCode: 200,
+      message: 'Success',
+      data: {
+        quizzes: [],
+        hasMore: false,
+        totalFeatured: 0,
+        totalAll: 0,
+        totalFree: 0,
+        totalPremium: 0,
+      },
+    };
+
+    httpMock.post.mockReturnValue(of(mockResponse));
+
+    service.browseQuizzes(mockPayload).subscribe((response) => {
+      expect(response).toEqual(mockResponse);
+      expect(httpMock.post).toHaveBeenCalledWith(
+        `${environment.baseUrl}/${EndPoints.BrowseQuizzes}`,
+        mockPayload,
+      );
+      done();
+    });
   });
 });

--- a/src/app/services/user/browse-quizzes/browse-quizzes.service.ts
+++ b/src/app/services/user/browse-quizzes/browse-quizzes.service.ts
@@ -1,8 +1,22 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ApiResponse } from '../../../shared/interfaces/api-response.interface';
+import { environment } from '../../../../environments/environment.dev';
+import { EndPoints } from '../../../shared/enums/end-point.enum';
+import { BrowseQuizzesRequest } from '../../../pages/user/browse-quizzes/interfaces/browsr-quiz-request.interface';
+import { BrowseQuizzesApiResponse } from '../../../pages/user/browse-quizzes/interfaces/browse-quiz-response.interface';
 
 @Injectable({
   providedIn: 'root',
 })
 export class BrowseQuizzesService {
-  constructor() {}
+  private readonly http = inject(HttpClient);
+
+  browseQuizzes(payload: BrowseQuizzesRequest): Observable<ApiResponse<BrowseQuizzesApiResponse>> {
+    return this.http.post<ApiResponse<BrowseQuizzesApiResponse>>(
+      `${environment.baseUrl}/${EndPoints.BrowseQuizzes}`,
+      payload,
+    );
+  }
 }


### PR DESCRIPTION
- adding Browse Quiz List FE with filters and search with responsiveness
- quiz card shows play quiz if not attempted, otherwise show result 

-- test cases 
<img width="1920" height="158" alt="image" src="https://github.com/user-attachments/assets/6179c8e8-f760-44ec-ba46-d7ec1da985af" />
<img width="1919" height="367" alt="image" src="https://github.com/user-attachments/assets/a2bc7790-4d2a-40a5-86b0-325f1f70cc98" />
<img width="1918" height="324" alt="image" src="https://github.com/user-attachments/assets/9a4ae776-f1b2-4ab3-851b-fdfc93a889ba" />
<img width="1920" height="311" alt="image" src="https://github.com/user-attachments/assets/d5b8f10d-80fc-4646-aef8-2ddb996a352a" />
<img width="1920" height="264" alt="image" src="https://github.com/user-attachments/assets/d026656f-ff4d-4fad-a8ba-21de72fed0a4" />

-- view
<img width="1917" height="944" alt="image" src="https://github.com/user-attachments/assets/2c79897d-2d16-4529-b97f-f017c7b54edb" />
<img width="1618" height="754" alt="image" src="https://github.com/user-attachments/assets/bb6f37d9-7869-467f-83e4-47c480d263d6" />
<img width="1649" height="869" alt="image" src="https://github.com/user-attachments/assets/13adaa68-251a-44e2-96bd-f56b8fb2126a" />
<img width="1638" height="861" alt="image" src="https://github.com/user-attachments/assets/ff1d94df-1ae9-4c72-a4c3-9a427526ec1b" />
<img width="1145" height="936" alt="image" src="https://github.com/user-attachments/assets/e9e0a34f-d878-4416-8fcd-56809186957e" />
<img width="879" height="954" alt="image" src="https://github.com/user-attachments/assets/3c55ca81-7a53-4ad4-8101-56ad406801ac" />
<img width="462" height="899" alt="image" src="https://github.com/user-attachments/assets/a51729cb-1074-42f0-9b84-02c4a202cef8" />
<img width="483" height="935" alt="image" src="https://github.com/user-attachments/assets/490b3bad-cb4a-4faa-94d3-d5c599e91f67" />
