### PR TITLE
flagged comments table and status change

### DIFF
--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-preview-dialog/flagged-comments-preview-dialog.component.html
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-preview-dialog/flagged-comments-preview-dialog.component.html
@@ -1,0 +1,89 @@
+<div class="dialog-container p-6 w-full">
+  <!-- Title -->
+  <h2 class="text-lg font-semibold text-gray-900 mb-1">Flagged Comment Details</h2>
+  <p class="text-sm text-gray-500 mb-5">Review the complete details of this flagged comment</p>
+
+  <button mat-icon-button class="close-btn-dialog-all" (click)="closeDialog()">
+    <mat-icon>close</mat-icon>
+  </button>
+
+  <!-- Comment Box -->
+  <div class="bg-gray-50 rounded-lg border border-gray-200 p-3 mb-5">
+    <p class="text-gray-800 text-sm break-words">
+      {{ flaggedCommentData?.comment || 'No comment available.' }}
+    </p>
+  </div>
+
+  <!-- Info Section -->
+  <div class="grid grid-cols-2 gap-4 text-sm text-gray-700">
+    <!-- Author -->
+    <div class="flex items-start space-x-3 break-words">
+      <div
+        class="w-8 h-8 items-center justify-center rounded-full text-white font-medium flex-shrink-0 hidden min-[450px]:flex"
+        [ngClass]="getInitialsColorClass(flaggedCommentData?.author!)"
+      >
+        {{ getInitials(flaggedCommentData?.author!) }}
+      </div>
+
+      <div class="min-w-0 flex-1">
+        <p class="font-medium text-gray-900">Author</p>
+        <p class="text-gray-700 break-words">{{ flaggedCommentData?.author }}</p>
+      </div>
+    </div>
+
+    <!-- Quiz -->
+    <div class="break-words">
+      <p class="font-medium text-gray-900">Quiz</p>
+      <p class="text-gray-700 break-words">{{ flaggedCommentData?.quizName }}</p>
+    </div>
+
+    <!-- Status -->
+    <div class="break-words">
+      <p class="font-medium text-gray-900">Status</p>
+      <app-tag [tagConfig]="getFlaggedCommentStatusConfig(flaggedCommentData?.status!)"></app-tag>
+    </div>
+
+    <!-- Date Added -->
+    <div class="break-words">
+      <p class="font-medium text-gray-900">Date Added</p>
+      <p class="text-gray-700">
+        {{ flaggedCommentData?.date | date: 'dd/MM/yyyy' }}
+      </p>
+    </div>
+
+    <!-- Reason for Flagging -->
+    <div class="col-span-2 break-words">
+      <p class="font-medium text-gray-900">Reason for Flagging</p>
+      <p class="text-gray-700 break-words">
+        {{ flaggedCommentData?.reason || 'No reason provided.' }}
+      </p>
+    </div>
+  </div>
+
+  <!-- Action Buttons -->
+  <div
+    class="flex flex-col min-[450px]:flex-row justify-end gap-3 mt-6 update-flagged-comment-buttons"
+  >
+    <app-outline-button
+      [outlineButtonConfig]="closeButtonConfig"
+      (click)="closeDialog()"
+    ></app-outline-button>
+    @if (flaggedCommentData?.status! === quizRatingStatus.Pending) {
+      <div class="flex flex-col min-[450px]:flex-row gap-3">
+        <app-filled-button
+          [filledButtonConfig]="ignoreReportButtonConfig"
+          (buttonClicked)="
+            handleFlaggedCommentAction(flaggedCommentData?.id!, quizRatingStatus.Ignore)
+          "
+        ></app-filled-button>
+
+        <app-filled-button
+          [filledButtonConfig]="acceptReportButtonConfig"
+          (buttonClicked)="
+            handleFlaggedCommentAction(flaggedCommentData?.id!, quizRatingStatus.Accepted)
+          "
+        ></app-filled-button>
+      </div>
+    }
+  </div>
+</div>

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-preview-dialog/flagged-comments-preview-dialog.component.scss
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-preview-dialog/flagged-comments-preview-dialog.component.scss
@@ -1,0 +1,59 @@
+.bg-avatar-0 {
+  background-color: #ffb703;
+  color: #000;
+}
+
+.bg-avatar-1 {
+  background-color: #fb8500;
+  color: #fff;
+}
+
+.bg-avatar-2 {
+  background-color: #219ebc;
+  color: #fff;
+}
+
+.bg-avatar-3 {
+  background-color: #8ecae6;
+  color: #000;
+}
+
+.bg-avatar-4 {
+  background-color: #ff006e;
+  color: #fff;
+}
+
+.bg-avatar-5 {
+  background-color: #8338ec;
+  color: #fff;
+}
+
+.bg-avatar-6 {
+  background-color: #3a86ff;
+  color: #fff;
+}
+
+.bg-avatar-7 {
+  background-color: #06d6a0;
+  color: #000;
+}
+
+.bg-avatar-8 {
+  background-color: #ef476f;
+  color: #fff;
+}
+
+.bg-avatar-9 {
+  background-color: #ffd166;
+  color: #000;
+}
+
+.bg-avatar-10 {
+  background-color: #118ab2;
+  color: #fff;
+}
+
+.bg-avatar-11 {
+  background-color: #073b4c;
+  color: #fff;
+}

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-preview-dialog/flagged-comments-preview-dialog.component.spec.ts
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-preview-dialog/flagged-comments-preview-dialog.component.spec.ts
@@ -1,0 +1,506 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FlaggedCommentsPreviewDialogComponent } from './flagged-comments-preview-dialog.component';
+import { FlaggedCommentsService } from '../../../../../../services/admin/content-moderation/flagged-comments.service';
+import { SnackbarService } from '../../../../../../shared/service/snackbar/snackbar.service';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { of, throwError, Subject } from 'rxjs';
+import { QuizRatingStatus } from '../../../../../../shared/enums/content-moderation.enum';
+import { FlaggedCommentView } from '../../../interfaces/flagged-comments.interface';
+import { platformMessages } from '../../../../../../utils/constants';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ConfirmationDialogComponent } from '../../../../../../shared/components/confirmation-dialog/confirmation-dialog.component';
+
+describe('FlaggedCommentsPreviewDialogComponent', () => {
+  let component: FlaggedCommentsPreviewDialogComponent;
+  let fixture: ComponentFixture<FlaggedCommentsPreviewDialogComponent>;
+  let mockFlaggedCommentsService: jest.Mocked<FlaggedCommentsService>;
+  let mockSnackbarService: jest.Mocked<SnackbarService>;
+  let mockDialogRef: jest.Mocked<MatDialogRef<FlaggedCommentsPreviewDialogComponent>>;
+  let mockDialog: jest.Mocked<MatDialog>;
+
+  const mockCommentId = 123;
+  const mockFlaggedCommentData: FlaggedCommentView = {
+    id: 123,
+    comment: 'This is a test comment',
+    author: 'John Doe',
+    quizName: 'Test Quiz',
+    reason: 'Inappropriate content',
+    date: new Date('2024-01-01'),
+    status: QuizRatingStatus.Pending,
+    quizCategory: 'Science',
+    userId: 456,
+  };
+
+  beforeEach(async () => {
+    mockFlaggedCommentsService = {
+      getFlaggedCommentsPreviewById: jest.fn(),
+      updateAction: jest.fn(),
+      notifyFlaggedCommentUpdated: jest.fn(),
+    } as any;
+
+    mockSnackbarService = {
+      showSuccess: jest.fn(),
+      showError: jest.fn(),
+    } as any;
+
+    mockDialogRef = {
+      close: jest.fn(),
+    } as any;
+
+    mockDialog = {
+      open: jest.fn(),
+    } as any;
+
+    await TestBed.configureTestingModule({
+      imports: [FlaggedCommentsPreviewDialogComponent],
+      providers: [
+        { provide: FlaggedCommentsService, useValue: mockFlaggedCommentsService },
+        { provide: SnackbarService, useValue: mockSnackbarService },
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MatDialog, useValue: mockDialog },
+        { provide: MAT_DIALOG_DATA, useValue: mockCommentId },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FlaggedCommentsPreviewDialogComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Component Initialization', () => {
+    it('should call loadflaggedCommentPreviewData on ngOnInit', () => {
+      jest.spyOn(component, 'loadflaggedCommentPreviewData');
+      mockFlaggedCommentsService.getFlaggedCommentsPreviewById.mockReturnValue(
+        of({ result: true, statusCode: 200, data: mockFlaggedCommentData, message: 'Success' }),
+      );
+
+      component.ngOnInit();
+
+      expect(component.loadflaggedCommentPreviewData).toHaveBeenCalledWith(mockCommentId);
+    });
+
+    it('should initialize with correct button configurations', () => {
+      expect(component.acceptReportButtonConfig).toBeDefined();
+      expect(component.ignoreReportButtonConfig).toBeDefined();
+      expect(component.closeButtonConfig).toBeDefined();
+    });
+
+    it('should initialize quizRatingStatus enum', () => {
+      expect(component.quizRatingStatus).toBe(QuizRatingStatus);
+    });
+  });
+
+  describe('loadflaggedCommentPreviewData', () => {
+    it('should load flagged comment data successfully', () => {
+      const mockResponse = {
+        result: true,
+        statusCode: 200,
+        data: mockFlaggedCommentData,
+        message: 'Success',
+      };
+      mockFlaggedCommentsService.getFlaggedCommentsPreviewById.mockReturnValue(of(mockResponse));
+
+      component.loadflaggedCommentPreviewData(mockCommentId);
+
+      expect(mockFlaggedCommentsService.getFlaggedCommentsPreviewById).toHaveBeenCalledWith(
+        mockCommentId,
+      );
+      expect(component.flaggedCommentData).toEqual(mockFlaggedCommentData);
+    });
+
+    it('should handle error from service', () => {
+      const errorMessage = 'Network error';
+      const error = { error: { message: errorMessage } };
+      mockFlaggedCommentsService.getFlaggedCommentsPreviewById.mockReturnValue(
+        throwError(() => error),
+      );
+
+      component.loadflaggedCommentPreviewData(mockCommentId);
+
+      expect(mockSnackbarService.showError).toHaveBeenCalledWith(
+        platformMessages.errorTitle,
+        errorMessage,
+      );
+    });
+
+    it('should use default error message when error.error.message is not available', () => {
+      mockFlaggedCommentsService.getFlaggedCommentsPreviewById.mockReturnValue(
+        throwError(() => ({})),
+      );
+
+      component.loadflaggedCommentPreviewData(mockCommentId);
+
+      expect(mockSnackbarService.showError).toHaveBeenCalledWith(
+        platformMessages.errorTitle,
+        platformMessages.failedToLoadCommentPreview,
+      );
+    });
+  });
+
+  describe('getFlaggedCommentStatusConfig', () => {
+    it('should return correct config for Accepted status', () => {
+      const config = component.getFlaggedCommentStatusConfig(QuizRatingStatus.Accepted);
+
+      expect(config).toBeDefined();
+      expect(config.id).toBe(`${QuizRatingStatus.Accepted}`);
+      expect(config.type).toBe('static');
+      expect(config.isSelected).toBe(false);
+      expect(config.hasBorder).toBe(false);
+    });
+
+    it('should return correct config for Ignore status', () => {
+      const config = component.getFlaggedCommentStatusConfig(QuizRatingStatus.Ignore);
+
+      expect(config).toBeDefined();
+      expect(config.id).toBe(`${QuizRatingStatus.Ignore}`);
+    });
+
+    it('should return correct config for Pending status', () => {
+      const config = component.getFlaggedCommentStatusConfig(QuizRatingStatus.Pending);
+
+      expect(config).toBeDefined();
+      expect(config.id).toBe(`${QuizRatingStatus.Pending}`);
+    });
+
+    it('should return correct config for UnderProcessing status', () => {
+      const config = component.getFlaggedCommentStatusConfig(QuizRatingStatus.UnderProcessing);
+
+      expect(config).toBeDefined();
+      expect(config.id).toBe(`${QuizRatingStatus.UnderProcessing}`);
+    });
+  });
+
+  describe('getInitials', () => {
+    it('should return initials for single name', () => {
+      const initials = component.getInitials('John');
+      expect(initials).toBeDefined();
+      expect(typeof initials).toBe('string');
+    });
+
+    it('should return initials for full name', () => {
+      const initials = component.getInitials('John Doe');
+      expect(initials).toBeDefined();
+      expect(typeof initials).toBe('string');
+    });
+
+    it('should handle empty string', () => {
+      const initials = component.getInitials('');
+      expect(initials).toBeDefined();
+    });
+  });
+
+  describe('getInitialsColorClass', () => {
+    it('should return color class for a name', () => {
+      const colorClass = component.getInitialsColorClass('John Doe');
+      expect(colorClass).toBeDefined();
+      expect(typeof colorClass).toBe('string');
+    });
+
+    it('should return consistent color class for same name', () => {
+      const colorClass1 = component.getInitialsColorClass('John Doe');
+      const colorClass2 = component.getInitialsColorClass('John Doe');
+      expect(colorClass1).toBe(colorClass2);
+    });
+
+    it('should handle empty string', () => {
+      const colorClass = component.getInitialsColorClass('');
+      expect(colorClass).toBeDefined();
+    });
+  });
+
+  describe('closeDialog', () => {
+    it('should call dialogRef.close', () => {
+      component.closeDialog();
+      expect(mockDialogRef.close).toHaveBeenCalled();
+    });
+
+    it('should call dialogRef.close only once', () => {
+      component.closeDialog();
+      expect(mockDialogRef.close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleFlaggedCommentAction', () => {
+    beforeEach(() => {
+      jest.spyOn(component, 'openConfirmationDialog');
+    });
+
+    it('should not open dialog for Pending status', () => {
+      component.handleFlaggedCommentAction(mockCommentId, QuizRatingStatus.Pending);
+
+      expect(component.openConfirmationDialog).not.toHaveBeenCalled();
+    });
+
+    it('should not open dialog for UnderProcessing status', () => {
+      component.handleFlaggedCommentAction(mockCommentId, QuizRatingStatus.UnderProcessing);
+
+      expect(component.openConfirmationDialog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('openConfirmationDialog', () => {
+    it('should open confirmation dialog with correct config', () => {
+      const mockDialogData = { title: 'Test', message: 'Test message' };
+      const mockOnConfirm = jest.fn();
+      const mockDialogRefFromOpen = {
+        afterClosed: jest.fn().mockReturnValue(of(false)),
+      };
+      mockDialog.open.mockReturnValue(mockDialogRefFromOpen as any);
+
+      component.openConfirmationDialog(mockDialogData as any, mockOnConfirm);
+
+      expect(mockDialog.open).toHaveBeenCalledWith(ConfirmationDialogComponent, {
+        width: '600px',
+        disableClose: false,
+        data: mockDialogData,
+        panelClass: 'custom-dialog-radius',
+      });
+    });
+
+    it('should call onConfirm when user confirms', () => {
+      const mockDialogData = { title: 'Test', message: 'Test message' };
+      const mockOnConfirm = jest.fn();
+      const mockDialogRefFromOpen = {
+        afterClosed: jest.fn().mockReturnValue(of(true)),
+      };
+      mockDialog.open.mockReturnValue(mockDialogRefFromOpen as any);
+
+      component.openConfirmationDialog(mockDialogData as any, mockOnConfirm);
+
+      expect(mockOnConfirm).toHaveBeenCalled();
+    });
+
+    it('should not call onConfirm when user cancels', () => {
+      const mockDialogData = { title: 'Test', message: 'Test message' };
+      const mockOnConfirm = jest.fn();
+      const mockDialogRefFromOpen = {
+        afterClosed: jest.fn().mockReturnValue(of(false)),
+      };
+      mockDialog.open.mockReturnValue(mockDialogRefFromOpen as any);
+
+      component.openConfirmationDialog(mockDialogData as any, mockOnConfirm);
+
+      expect(mockOnConfirm).not.toHaveBeenCalled();
+    });
+
+    it('should not call onConfirm when dialog is dismissed', () => {
+      const mockDialogData = { title: 'Test', message: 'Test message' };
+      const mockOnConfirm = jest.fn();
+      const mockDialogRefFromOpen = {
+        afterClosed: jest.fn().mockReturnValue(of(undefined)),
+      };
+      mockDialog.open.mockReturnValue(mockDialogRefFromOpen as any);
+
+      component.openConfirmationDialog(mockDialogData as any, mockOnConfirm);
+
+      expect(mockOnConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateQueReportStatus', () => {
+    it('should update status successfully', () => {
+      const mockResponse = {
+        result: true,
+        statusCode: 200,
+        message: 'Status updated successfully',
+        data: null,
+      };
+      mockFlaggedCommentsService.updateAction.mockReturnValue(of(mockResponse));
+      mockFlaggedCommentsService.getFlaggedCommentsPreviewById.mockReturnValue(
+        of({ result: true, statusCode: 200, data: mockFlaggedCommentData, message: 'Success' }),
+      );
+      jest.spyOn(component, 'loadflaggedCommentPreviewData');
+
+      component.updateQueReportStatus(mockCommentId, QuizRatingStatus.Accepted);
+
+      expect(mockFlaggedCommentsService.updateAction).toHaveBeenCalledWith({
+        id: mockCommentId,
+        status: QuizRatingStatus.Accepted,
+      });
+      expect(mockSnackbarService.showSuccess).toHaveBeenCalledWith(
+        platformMessages.successTitle,
+        mockResponse.message,
+      );
+      expect(component.loadflaggedCommentPreviewData).toHaveBeenCalledWith(mockCommentId);
+      expect(mockFlaggedCommentsService.notifyFlaggedCommentUpdated).toHaveBeenCalled();
+    });
+
+    it('should show error when update fails with result false', () => {
+      const mockResponse = {
+        result: false,
+        statusCode: 400,
+        message: 'Update failed',
+        data: null,
+      };
+      mockFlaggedCommentsService.updateAction.mockReturnValue(of(mockResponse));
+
+      component.updateQueReportStatus(mockCommentId, QuizRatingStatus.Accepted);
+
+      expect(mockSnackbarService.showError).toHaveBeenCalledWith(
+        platformMessages.errorTitle,
+        mockResponse.message,
+      );
+      expect(mockFlaggedCommentsService.notifyFlaggedCommentUpdated).not.toHaveBeenCalled();
+    });
+
+    it('should show error when update fails with non-200 status code', () => {
+      const mockResponse = {
+        result: true,
+        statusCode: 500,
+        message: 'Server error',
+        data: null,
+      };
+      mockFlaggedCommentsService.updateAction.mockReturnValue(of(mockResponse));
+
+      component.updateQueReportStatus(mockCommentId, QuizRatingStatus.Ignore);
+
+      expect(mockSnackbarService.showError).toHaveBeenCalledWith(
+        platformMessages.errorTitle,
+        mockResponse.message,
+      );
+    });
+
+    it('should handle error from service', () => {
+      const errorMessage = 'Network error';
+      const error = { error: { message: errorMessage } };
+      mockFlaggedCommentsService.updateAction.mockReturnValue(throwError(() => error));
+
+      component.updateQueReportStatus(mockCommentId, QuizRatingStatus.Accepted);
+
+      expect(mockSnackbarService.showError).toHaveBeenCalledWith(
+        platformMessages.errorTitle,
+        errorMessage,
+      );
+    });
+
+    it('should use default error message when error.error.message is not available', () => {
+      mockFlaggedCommentsService.updateAction.mockReturnValue(throwError(() => ({})));
+
+      component.updateQueReportStatus(mockCommentId, QuizRatingStatus.Accepted);
+
+      expect(mockSnackbarService.showError).toHaveBeenCalledWith(
+        platformMessages.errorTitle,
+        platformMessages.errorMessage,
+      );
+    });
+
+    it('should update with Ignore status', () => {
+      const mockResponse = {
+        result: true,
+        statusCode: 200,
+        message: 'Status updated successfully',
+        data: null,
+      };
+      mockFlaggedCommentsService.updateAction.mockReturnValue(of(mockResponse));
+      mockFlaggedCommentsService.getFlaggedCommentsPreviewById.mockReturnValue(
+        of({ result: true, statusCode: 200, data: mockFlaggedCommentData, message: 'Success' }),
+      );
+
+      component.updateQueReportStatus(mockCommentId, QuizRatingStatus.Ignore);
+
+      expect(mockFlaggedCommentsService.updateAction).toHaveBeenCalledWith({
+        id: mockCommentId,
+        status: QuizRatingStatus.Ignore,
+      });
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('should complete destroy$ subject', () => {
+      const destroySpy = jest.spyOn(component['destroy$'], 'next');
+      const completeSpy = jest.spyOn(component['destroy$'], 'complete');
+
+      component.ngOnDestroy();
+
+      expect(destroySpy).toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalled();
+    });
+
+    it('should unsubscribe from all observables', () => {
+      const mockResponse = {
+        result: true,
+        statusCode: 200,
+        data: mockFlaggedCommentData,
+        message: 'Success',
+      };
+      mockFlaggedCommentsService.getFlaggedCommentsPreviewById.mockReturnValue(of(mockResponse));
+
+      component.ngOnInit();
+      component.ngOnDestroy();
+
+      expect(component['destroy$'].closed).toBe(false);
+      expect(component['destroy$'].observers.length).toBe(0);
+    });
+  });
+
+  describe('Integration Tests', () => {
+    it('should handle complete flow of accepting a comment', () => {
+      const mockDialogRefFromOpen = {
+        afterClosed: jest.fn().mockReturnValue(of(true)),
+      };
+      mockDialog.open.mockReturnValue(mockDialogRefFromOpen as any);
+
+      const mockUpdateResponse = {
+        result: true,
+        statusCode: 200,
+        message: 'Comment accepted',
+        data: null,
+      };
+      mockFlaggedCommentsService.updateAction.mockReturnValue(of(mockUpdateResponse));
+      mockFlaggedCommentsService.getFlaggedCommentsPreviewById.mockReturnValue(
+        of({ result: true, statusCode: 200, data: mockFlaggedCommentData, message: 'Success' }),
+      );
+
+      component.handleFlaggedCommentAction(mockCommentId, QuizRatingStatus.Accepted);
+
+      expect(mockDialog.open).toHaveBeenCalled();
+      expect(mockFlaggedCommentsService.updateAction).toHaveBeenCalledWith({
+        id: mockCommentId,
+        status: QuizRatingStatus.Accepted,
+      });
+      expect(mockSnackbarService.showSuccess).toHaveBeenCalled();
+    });
+
+    it('should handle complete flow of ignoring a comment', () => {
+      const mockDialogRefFromOpen = {
+        afterClosed: jest.fn().mockReturnValue(of(true)),
+      };
+      mockDialog.open.mockReturnValue(mockDialogRefFromOpen as any);
+
+      const mockUpdateResponse = {
+        result: true,
+        statusCode: 200,
+        message: 'Comment ignored',
+        data: null,
+      };
+      mockFlaggedCommentsService.updateAction.mockReturnValue(of(mockUpdateResponse));
+      mockFlaggedCommentsService.getFlaggedCommentsPreviewById.mockReturnValue(
+        of({ result: true, statusCode: 200, data: mockFlaggedCommentData, message: 'Success' }),
+      );
+
+      component.handleFlaggedCommentAction(mockCommentId, QuizRatingStatus.Ignore);
+
+      expect(mockDialog.open).toHaveBeenCalled();
+      expect(mockFlaggedCommentsService.updateAction).toHaveBeenCalledWith({
+        id: mockCommentId,
+        status: QuizRatingStatus.Ignore,
+      });
+    });
+
+    it('should not update status when user cancels confirmation dialog', () => {
+      const mockDialogRefFromOpen = {
+        afterClosed: jest.fn().mockReturnValue(of(false)),
+      };
+      mockDialog.open.mockReturnValue(mockDialogRefFromOpen as any);
+
+      component.handleFlaggedCommentAction(mockCommentId, QuizRatingStatus.Accepted);
+
+      expect(mockDialog.open).toHaveBeenCalled();
+      expect(mockFlaggedCommentsService.updateAction).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-preview-dialog/flagged-comments-preview-dialog.component.ts
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-preview-dialog/flagged-comments-preview-dialog.component.ts
@@ -1,0 +1,172 @@
+import { Component, HostListener, inject, NgZone, OnDestroy, OnInit } from '@angular/core';
+import { FlaggedCommentsService } from '../../../../../../services/admin/content-moderation/flagged-comments.service';
+import { SnackbarService } from '../../../../../../shared/service/snackbar/snackbar.service';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import {
+  FlaggedCommentView,
+  UpdateFlaggedCommentStatusRequest,
+} from '../../../interfaces/flagged-comments.interface';
+import { Subject, takeUntil } from 'rxjs';
+import { flaggedCommentsAction, platformMessages } from '../../../../../../utils/constants';
+import { TagInputConfig } from '../../../../../../shared/interfaces/tag-component.interface';
+import {
+  getStatusColor,
+  getStatusLabel,
+} from '../flagged-comments-table/flagged-comments-table.mapper';
+import { TagColor } from '../../../../../../utils/types/tag-component.type';
+import {
+  globalGetInitials,
+  globalGetInitialsColorClass,
+} from '../../../../../../utils/get-profile-initials.utils';
+import { TagComponent } from '../../../../../../shared/components/tag/tag.component';
+import { FilledButtonComponent } from '../../../../../../shared/components/filled-button/filled-button.component';
+import { OutlineButtonComponent } from '../../../../../../shared/components/outline-button/outline-button.component';
+import { CommonModule } from '@angular/common';
+import {
+  acceptedDialog,
+  acceptReportButtonConfig,
+  acceptReportForDialogButtonConfig,
+  cancelButtonConfig,
+  closeButtonConfig,
+  ignoreButtonConfig,
+  ignoredDialog,
+  ignoreReportForDialogButtonConfig,
+} from '../../../configs/flagged-comment-confirmation-dialog.config';
+import { MatIcon } from '@angular/material/icon';
+import { QuizRatingStatus } from '../../../../../../shared/enums/content-moderation.enum';
+import { ConfirmationDialogData } from '../../../../../../shared/interfaces/confirmation-dialog.interface';
+import { ConfirmationDialogComponent } from '../../../../../../shared/components/confirmation-dialog/confirmation-dialog.component';
+
+@Component({
+  selector: 'app-flagged-comments-preview-dialog',
+  imports: [TagComponent, FilledButtonComponent, OutlineButtonComponent, CommonModule, MatIcon],
+  templateUrl: './flagged-comments-preview-dialog.component.html',
+  styleUrl: './flagged-comments-preview-dialog.component.scss',
+})
+export class FlaggedCommentsPreviewDialogComponent implements OnInit, OnDestroy {
+  flaggedCommentData: FlaggedCommentView;
+  acceptReportButtonConfig = { ...acceptReportForDialogButtonConfig };
+  ignoreReportButtonConfig = { ...ignoreReportForDialogButtonConfig };
+  closeButtonConfig = closeButtonConfig;
+  dialog = inject(MatDialog);
+  quizRatingStatus = QuizRatingStatus;
+  private readonly flaggedCommentService = inject(FlaggedCommentsService);
+  private readonly snackbar = inject(SnackbarService);
+  private readonly dialogRef = inject(MatDialogRef<FlaggedCommentsPreviewDialogComponent>);
+  private readonly data = inject<number>(MAT_DIALOG_DATA);
+  private readonly destroy$ = new Subject<void>();
+
+  ngOnInit(): void {
+    this.loadflaggedCommentPreviewData(this.data);
+  }
+
+  loadflaggedCommentPreviewData(commentId: number): void {
+    this.flaggedCommentService
+      .getFlaggedCommentsPreviewById(commentId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          if (res.result && res.statusCode === 200) {
+            this.flaggedCommentData = res.data;
+          } else {
+            this.snackbar.showError(
+              platformMessages.errorTitle,
+              platformMessages.failedToLoadCommentPreview,
+            );
+          }
+        },
+        error: (err) => {
+          this.snackbar.showError(
+            platformMessages.errorTitle,
+            err?.error?.message || platformMessages.failedToLoadCommentPreview,
+          );
+        },
+      });
+  }
+
+  getFlaggedCommentStatusConfig(status: number): TagInputConfig {
+    const colors = getStatusColor(status);
+    return {
+      id: `${status}`,
+      label: getStatusLabel(status),
+      type: 'static',
+      isSelected: false,
+      hasBorder: false,
+      backgroundColor: colors.bg as TagColor,
+      textColor: colors.text as TagColor,
+    };
+  }
+
+  // Return initials for a given name
+  getInitials(name: string): string {
+    return globalGetInitials(name);
+  }
+
+  // Return color class for user avatar based on name hash
+  getInitialsColorClass(name: string): string {
+    return globalGetInitialsColorClass(name);
+  }
+
+  closeDialog(): void {
+    this.dialogRef.close();
+  }
+
+  handleFlaggedCommentAction(commentId: number, event: number): void {
+    switch (event) {
+      case QuizRatingStatus.Accepted:
+        this.openConfirmationDialog(acceptedDialog, () =>
+          this.updateQueReportStatus(commentId as number, QuizRatingStatus.Accepted),
+        );
+        break;
+      case QuizRatingStatus.Ignore:
+        this.openConfirmationDialog(ignoredDialog, () =>
+          this.updateQueReportStatus(commentId as number, QuizRatingStatus.Ignore),
+        );
+        break;
+    }
+  }
+
+  openConfirmationDialog(dialogData: ConfirmationDialogData, onConfirm: () => void): void {
+    const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
+      width: '600px',
+      disableClose: false,
+      data: dialogData,
+      panelClass: 'custom-dialog-radius',
+    });
+
+    dialogRef.afterClosed().subscribe((confirmed) => {
+      if (confirmed) onConfirm();
+    });
+  }
+
+  updateQueReportStatus(commentId: number, newStatus: QuizRatingStatus): void {
+    const payload: UpdateFlaggedCommentStatusRequest = {
+      id: commentId,
+      status: newStatus,
+    };
+    this.flaggedCommentService
+      .updateAction(payload)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          if (res.result && res.statusCode === 200) {
+            this.snackbar.showSuccess(platformMessages.successTitle, res.message);
+            this.loadflaggedCommentPreviewData(this.data);
+            this.flaggedCommentService.notifyFlaggedCommentUpdated();
+          } else {
+            this.snackbar.showError(platformMessages.errorTitle, res.message);
+          }
+        },
+        error: (err) =>
+          this.snackbar.showError(
+            platformMessages.errorTitle,
+            err?.error?.message || platformMessages.errorMessage,
+          ),
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-table/flagged-comments-table.component.html
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-table/flagged-comments-table.component.html
@@ -1,0 +1,13 @@
+<app-data-table
+  [columns]="columns"
+  [dataSource]="dataSource"
+  [totalItems]="totalItems"
+  [pageSize]="paginationConfig.pageSize"
+  [pageSizeOptions]="paginationConfig.pageSizeOptions"
+  [applyPaginator]="paginationConfig.applyPaginator"
+  (actionClick)="onActionClick($event)"
+  (pageChange)="onPageChange($event)"
+  (sortChange)="onSortChange($event)"
+  class="flagged-comments-table"
+>
+</app-data-table>

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-table/flagged-comments-table.component.spec.ts
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-table/flagged-comments-table.component.spec.ts
@@ -1,0 +1,327 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FlaggedCommentsTableComponent } from './flagged-comments-table.component';
+import { TableComponent } from '../../../../../../shared/components/table/table.component';
+import { TableData } from '../../../../../../shared/interfaces/table-component.interface';
+import {
+  flaggedCommentsTableColumnsConfig,
+  flaggedCommentsTablePaginationConfig,
+} from '../../../configs/flagged-comments-table.config';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+describe('FlaggedCommentsTableComponent', () => {
+  let component: FlaggedCommentsTableComponent;
+  let fixture: ComponentFixture<FlaggedCommentsTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FlaggedCommentsTableComponent],
+      schemas: [NO_ERRORS_SCHEMA], // Ignore child component template errors
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FlaggedCommentsTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Component Initialization', () => {
+    it('should initialize with empty dataSource', () => {
+      expect(component.dataSource).toEqual([]);
+    });
+
+    it('should initialize with totalItems as 0', () => {
+      expect(component.totalItems).toBe(0);
+    });
+
+    it('should have correct columns configuration', () => {
+      expect(component.columns).toEqual(flaggedCommentsTableColumnsConfig);
+      expect(component.columns.length).toBe(7);
+    });
+
+    it('should have correct pagination configuration', () => {
+      expect(component.paginationConfig).toEqual(flaggedCommentsTablePaginationConfig);
+    });
+  });
+
+  describe('Input Properties', () => {
+    it('should accept dataSource input', () => {
+      const mockData: TableData[] = [
+        {
+          comment: 'Test comment',
+          author: 'John Doe',
+          quizName: 'Quiz 1',
+          reason: 'Spam',
+          date: '2024-01-01',
+          status: 'pending',
+        },
+      ];
+      component.dataSource = mockData;
+      expect(component.dataSource).toEqual(mockData);
+    });
+
+    it('should accept totalItems input', () => {
+      component.totalItems = 100;
+      expect(component.totalItems).toBe(100);
+    });
+
+    it('should handle empty dataSource', () => {
+      component.dataSource = [];
+      expect(component.dataSource).toEqual([]);
+      expect(component.dataSource.length).toBe(0);
+    });
+
+    it('should handle large dataSource', () => {
+      const mockData: TableData[] = Array.from({ length: 100 }, (_, i) => ({
+        comment: `Comment ${i}`,
+        author: `Author ${i}`,
+        quizName: `Quiz ${i}`,
+        reason: 'Test',
+        date: '2024-01-01',
+        status: 'pending',
+      }));
+      component.dataSource = mockData;
+      expect(component.dataSource.length).toBe(100);
+    });
+  });
+
+  describe('Output Events', () => {
+    it('should have pageChange output emitter', () => {
+      expect(component.pageChange).toBeDefined();
+    });
+
+    it('should have sortChange output emitter', () => {
+      expect(component.sortChange).toBeDefined();
+    });
+
+    it('should have actionClick output emitter', () => {
+      expect(component.actionClick).toBeDefined();
+    });
+  });
+
+  describe('onActionClick', () => {
+    it('should emit actionClick event with correct data', () => {
+      const mockRow: TableData = {
+        comment: 'Test comment',
+        author: 'John Doe',
+        quizName: 'Quiz 1',
+        reason: 'Spam',
+        date: '2024-01-01',
+        status: 'pending',
+      };
+      const mockEvent = { action: 'edit', row: mockRow };
+
+      jest.spyOn(component.actionClick, 'emit');
+      component.onActionClick(mockEvent);
+
+      expect(component.actionClick.emit).toHaveBeenCalledWith(mockEvent);
+      expect(component.actionClick.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should emit actionClick with delete action', () => {
+      const mockRow: TableData = {
+        comment: 'Test comment',
+        author: 'Jane Doe',
+      };
+      const mockEvent = { action: 'delete', row: mockRow };
+
+      jest.spyOn(component.actionClick, 'emit');
+      component.onActionClick(mockEvent);
+
+      expect(component.actionClick.emit).toHaveBeenCalledWith(mockEvent);
+    });
+
+    it('should emit actionClick with block action', () => {
+      const mockRow: TableData = {
+        comment: 'Inappropriate comment',
+        author: 'Bad User',
+      };
+      const mockEvent = { action: 'block', row: mockRow };
+
+      jest.spyOn(component.actionClick, 'emit');
+      component.onActionClick(mockEvent);
+
+      expect(component.actionClick.emit).toHaveBeenCalledWith(mockEvent);
+    });
+  });
+
+  describe('onPageChange', () => {
+    it('should emit pageChange event with correct data', () => {
+      const mockEvent = { pageIndex: 2, pageSize: 10 };
+
+      jest.spyOn(component.pageChange, 'emit');
+      component.onPageChange(mockEvent);
+
+      expect(component.pageChange.emit).toHaveBeenCalledWith(mockEvent);
+      expect(component.pageChange.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should emit pageChange with pageIndex 0', () => {
+      const mockEvent = { pageIndex: 0, pageSize: 10 };
+
+      jest.spyOn(component.pageChange, 'emit');
+      component.onPageChange(mockEvent);
+
+      expect(component.pageChange.emit).toHaveBeenCalledWith(mockEvent);
+    });
+
+    it('should emit pageChange with different pageSize', () => {
+      const mockEvent = { pageIndex: 1, pageSize: 25 };
+
+      jest.spyOn(component.pageChange, 'emit');
+      component.onPageChange(mockEvent);
+
+      expect(component.pageChange.emit).toHaveBeenCalledWith(mockEvent);
+    });
+
+    it('should emit pageChange with large pageIndex', () => {
+      const mockEvent = { pageIndex: 99, pageSize: 10 };
+
+      jest.spyOn(component.pageChange, 'emit');
+      component.onPageChange(mockEvent);
+
+      expect(component.pageChange.emit).toHaveBeenCalledWith(mockEvent);
+    });
+  });
+
+  describe('onSortChange', () => {
+    it('should emit sortChange event with correct data', () => {
+      const mockEvent = { active: 'comment', direction: 'asc' };
+
+      jest.spyOn(component.sortChange, 'emit');
+      component.onSortChange(mockEvent);
+
+      expect(component.sortChange.emit).toHaveBeenCalledWith(mockEvent);
+      expect(component.sortChange.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should emit sortChange with descending direction', () => {
+      const mockEvent = { active: 'date', direction: 'desc' };
+
+      jest.spyOn(component.sortChange, 'emit');
+      component.onSortChange(mockEvent);
+
+      expect(component.sortChange.emit).toHaveBeenCalledWith(mockEvent);
+    });
+
+    it('should emit sortChange for author column', () => {
+      const mockEvent = { active: 'author', direction: 'asc' };
+
+      jest.spyOn(component.sortChange, 'emit');
+      component.onSortChange(mockEvent);
+
+      expect(component.sortChange.emit).toHaveBeenCalledWith(mockEvent);
+    });
+
+    it('should emit sortChange for status column', () => {
+      const mockEvent = { active: 'status', direction: 'desc' };
+
+      jest.spyOn(component.sortChange, 'emit');
+      component.onSortChange(mockEvent);
+
+      expect(component.sortChange.emit).toHaveBeenCalledWith(mockEvent);
+    });
+
+    it('should emit sortChange with empty direction', () => {
+      const mockEvent = { active: 'comment', direction: '' };
+
+      jest.spyOn(component.sortChange, 'emit');
+      component.onSortChange(mockEvent);
+
+      expect(component.sortChange.emit).toHaveBeenCalledWith(mockEvent);
+    });
+  });
+
+  describe('Column Configuration', () => {
+    it('should have comment column configured correctly', () => {
+      const commentColumn = component.columns.find((col) => col.key === 'comment');
+      expect(commentColumn).toBeDefined();
+      expect(commentColumn?.label).toBe('Comments');
+      expect(commentColumn?.type).toBe('text');
+      expect(commentColumn?.isSortable).toBe(true);
+    });
+
+    it('should have author column configured correctly', () => {
+      const authorColumn = component.columns.find((col) => col.key === 'author');
+      expect(authorColumn).toBeDefined();
+      expect(authorColumn?.label).toBe('Author');
+      expect(authorColumn?.type).toBe('text');
+      expect(authorColumn?.isSortable).toBe(true);
+    });
+
+    it('should have status column configured as tag type', () => {
+      const statusColumn = component.columns.find((col) => col.key === 'status');
+      expect(statusColumn).toBeDefined();
+      expect(statusColumn?.type).toBe('tag');
+      expect(statusColumn?.isSortable).toBe(true);
+    });
+
+    it('should have actions column configured correctly', () => {
+      const actionsColumn = component.columns.find((col) => col.key === 'actions');
+      expect(actionsColumn).toBeDefined();
+      expect(actionsColumn?.label).toBe('Actions');
+      expect(actionsColumn?.type).toBe('button');
+      expect(actionsColumn?.isSortable).toBe(false);
+    });
+
+    it('should have all expected columns', () => {
+      const expectedKeys = ['comment', 'author', 'quizName', 'reason', 'date', 'status', 'actions'];
+      const actualKeys = component.columns.map((col) => col.key);
+      expect(actualKeys).toEqual(expectedKeys);
+    });
+  });
+
+  describe('Pagination Configuration', () => {
+    it('should have applyPaginator set to true', () => {
+      expect(component.paginationConfig.applyPaginator).toBe(true);
+    });
+
+    it('should have pageSize defined', () => {
+      expect(component.paginationConfig.pageSize).toBeDefined();
+      expect(typeof component.paginationConfig.pageSize).toBe('number');
+    });
+
+    it('should have pageSizeOptions defined', () => {
+      expect(component.paginationConfig.pageSizeOptions).toBeDefined();
+      expect(Array.isArray(component.paginationConfig.pageSizeOptions)).toBe(true);
+    });
+  });
+
+  describe('Event Emission Integration', () => {
+    it('should emit all three event types independently', () => {
+      jest.spyOn(component.actionClick, 'emit');
+      jest.spyOn(component.pageChange, 'emit');
+      jest.spyOn(component.sortChange, 'emit');
+
+      component.onActionClick({ action: 'edit', row: {} });
+      component.onPageChange({ pageIndex: 1, pageSize: 10 });
+      component.onSortChange({ active: 'comment', direction: 'asc' });
+
+      expect(component.actionClick.emit).toHaveBeenCalledTimes(1);
+      expect(component.pageChange.emit).toHaveBeenCalledTimes(1);
+      expect(component.sortChange.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle multiple action clicks', () => {
+      jest.spyOn(component.actionClick, 'emit');
+
+      component.onActionClick({ action: 'edit', row: {} });
+      component.onActionClick({ action: 'delete', row: {} });
+      component.onActionClick({ action: 'block', row: {} });
+
+      expect(component.actionClick.emit).toHaveBeenCalledTimes(3);
+    });
+
+    it('should handle multiple page changes', () => {
+      jest.spyOn(component.pageChange, 'emit');
+
+      component.onPageChange({ pageIndex: 0, pageSize: 10 });
+      component.onPageChange({ pageIndex: 1, pageSize: 10 });
+      component.onPageChange({ pageIndex: 2, pageSize: 25 });
+
+      expect(component.pageChange.emit).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-table/flagged-comments-table.component.ts
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-table/flagged-comments-table.component.ts
@@ -1,0 +1,40 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { TableData } from '../../../../../../shared/interfaces/table-component.interface';
+import {
+  flaggedCommentsTableColumnsConfig,
+  flaggedCommentsTablePaginationConfig,
+} from '../../../configs/flagged-comments-table.config';
+import { TableComponent } from '../../../../../../shared/components/table/table.component';
+
+@Component({
+  selector: 'app-flagged-comments-table',
+  imports: [TableComponent],
+  templateUrl: './flagged-comments-table.component.html',
+  styleUrl: './flagged-comments-table.component.scss',
+})
+export class FlaggedCommentsTableComponent {
+  @Input() dataSource: TableData[] = []; // Input data to be displayed in the table
+  @Input() totalItems = 0; // Total number of items for pagination
+
+  @Output() pageChange = new EventEmitter<{ pageIndex: number; pageSize: number }>(); // Emits event when pagination changes
+  @Output() sortChange = new EventEmitter<{ active: string; direction: string }>(); // Emits event when sorting changes
+  @Output() actionClick = new EventEmitter<{ action: string; row: TableData }>(); // Emits event when any action button (edit/delete/block etc.) is clicked
+
+  columns = flaggedCommentsTableColumnsConfig; // Table column configuration
+  paginationConfig = flaggedCommentsTablePaginationConfig; // Pagination settings
+
+  // Emits the clicked action and row to the parent
+  onActionClick(event: { action: string; row: TableData }) {
+    this.actionClick.emit(event);
+  }
+
+  // Emits page change event to the parent
+  onPageChange(event: { pageIndex: number; pageSize: number }) {
+    this.pageChange.emit(event);
+  }
+
+  // Emits sort change event to the parent
+  onSortChange(event: { active: string; direction: string }) {
+    this.sortChange.emit(event);
+  }
+}

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-table/flagged-comments-table.mapper.spec.ts
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-table/flagged-comments-table.mapper.spec.ts
@@ -1,0 +1,132 @@
+import { QuizRatingStatus } from '../../../../../../shared/enums/content-moderation.enum';
+import { colors, flaggedCommentsAction } from '../../../../../../utils/constants';
+import {
+  flaggedCommentsToTableData,
+  getStatusColor,
+  getStatusLabel,
+} from './flagged-comments-table.mapper';
+
+describe('Flagged Comments Utils', () => {
+  describe('getStatusLabel', () => {
+    it('should return correct label for each status', () => {
+      expect(getStatusLabel(QuizRatingStatus.Accepted)).toBe('Accepted');
+      expect(getStatusLabel(QuizRatingStatus.Ignore)).toBe('Ignored');
+      expect(getStatusLabel(QuizRatingStatus.Pending)).toBe('Pending');
+      expect(getStatusLabel(QuizRatingStatus.UnderProcessing)).toBe('Under Processing');
+    });
+
+    it('should return "Unknown" for an invalid status', () => {
+      expect(getStatusLabel(999)).toBe('Unknown');
+    });
+  });
+
+  describe('getStatusColor', () => {
+    it('should return correct color for each status', () => {
+      expect(getStatusColor(QuizRatingStatus.Accepted)).toEqual(colors.green);
+      expect(getStatusColor(QuizRatingStatus.Ignore)).toEqual(colors.red);
+      expect(getStatusColor(QuizRatingStatus.Pending)).toEqual(colors.blue);
+      expect(getStatusColor(QuizRatingStatus.UnderProcessing)).toEqual(colors.yellow);
+    });
+
+    it('should return black for an unknown status', () => {
+      expect(getStatusColor(999)).toEqual(colors.black);
+    });
+  });
+
+  describe('flaggedCommentsToTableData', () => {
+    const baseComment = {
+      id: 1,
+      comment: 'This is a test comment for moderation',
+      author: 'Test User',
+      quizName: 'Sample Quiz',
+      reason: 'Offensive content',
+      date: new Date('2024-10-10'),
+      status: QuizRatingStatus.Pending,
+    };
+
+    it('should map flagged comment to table data correctly', () => {
+      const result = flaggedCommentsToTableData(baseComment) as any;
+      expect(result['id']).toBe(1);
+      expect(result['author']).toBe('Test User');
+      expect(result['quizName']).toBe('Sample Quiz');
+      expect(result['reason']).toBe('Offensive content');
+      expect(result['status']).toBeDefined();
+      expect(result['actions'].length).toBe(3);
+    });
+
+    it('should truncate long comments with an ellipsis', () => {
+      const longComment = { ...baseComment, comment: 'A'.repeat(100) };
+      const result = flaggedCommentsToTableData(longComment) as any;
+      expect(result['comment'].endsWith('…')).toBe(true);
+      expect(result['comment'].length).toBeLessThan(100);
+    });
+
+    it('should not truncate short comments', () => {
+      const shortComment = { ...baseComment, comment: 'Short comment' };
+      const result = flaggedCommentsToTableData(shortComment);
+      expect(result['comment']).toBe('Short comment');
+    });
+
+    it('should correctly assign status label and colors', () => {
+      const acceptedComment = { ...baseComment, status: QuizRatingStatus.Accepted };
+      const result = flaggedCommentsToTableData(acceptedComment) as any;
+      expect(result['status']['tagConfig']['label']).toBe('Accepted');
+      expect(result['status']['tagConfig']['backgroundColor']).toBe(colors.green.bg);
+      expect(result['status']['tagConfig']['textColor']).toBe(colors.green.text);
+    });
+
+    it('should disable Accept and Ignore buttons when status is Accepted', () => {
+      const comment = { ...baseComment, status: QuizRatingStatus.Accepted };
+      const result = flaggedCommentsToTableData(comment) as any;
+      const actions = result['actions'];
+
+      expect(actions[1]['isDisabled']).toBe(true);
+      expect(actions[2]['isDisabled']).toBe(true);
+      expect(actions[1]['tooltip']).toBe('Already Accepted');
+      expect(actions[2]['tooltip']).toBe('Already Accepted');
+    });
+
+    it('should disable Accept and Ignore buttons when status is Ignored', () => {
+      const comment = { ...baseComment, status: QuizRatingStatus.Ignore };
+      const result = flaggedCommentsToTableData(comment) as any;
+      const actions = result['actions'];
+
+      expect(actions[1]['isDisabled']).toBe(true);
+      expect(actions[2]['isDisabled']).toBe(true);
+      expect(actions[1]['tooltip']).toBe('Already Ignored');
+      expect(actions[2]['tooltip']).toBe('Already Ignored');
+    });
+
+    it('should enable Accept and Ignore buttons when status is Pending', () => {
+      const comment = { ...baseComment, status: QuizRatingStatus.Pending };
+      const result = flaggedCommentsToTableData(comment) as any;
+      const actions = result['actions'];
+
+      expect(actions[1]['isDisabled']).toBe(false);
+      expect(actions[2]['isDisabled']).toBe(false);
+      expect(actions[1]['tooltip']).toBe('Accept Report');
+      expect(actions[2]['tooltip']).toBe('Ignore Report');
+    });
+
+    it('should correctly handle UnderProcessing status', () => {
+      const comment = { ...baseComment, status: QuizRatingStatus.UnderProcessing };
+      const result = flaggedCommentsToTableData(comment) as any;
+      expect(result['status']['tagConfig']['label']).toBe('Under Processing');
+      expect(result['status']['tagConfig']['backgroundColor']).toBe(colors.yellow.bg);
+    });
+
+    it('should correctly map date to a formatted string', () => {
+      const result = flaggedCommentsToTableData(baseComment);
+      expect(typeof result['date']).toBe('string');
+      expect(result['date']).toContain('10');
+    });
+
+    it('should assign proper icons for actions', () => {
+      const result = flaggedCommentsToTableData(baseComment) as any;
+      const icons = result['actions'].map((a: any) => a['icon']);
+      expect(icons).toContain(flaggedCommentsAction.VIEW);
+      expect(icons).toContain(flaggedCommentsAction.ACCEPTED);
+      expect(icons).toContain(flaggedCommentsAction.IGNORED);
+    });
+  });
+});

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-table/flagged-comments-table.mapper.ts
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments-table/flagged-comments-table.mapper.ts
@@ -1,0 +1,117 @@
+import {
+  QuestionOrQuizIssueReportSeverity,
+  QuestionOrQuizIssueReportStatus,
+  QuizRatingStatus,
+} from '../../../../../../shared/enums/content-moderation.enum';
+import { TableData } from '../../../../../../shared/interfaces/table-component.interface';
+import { colors, flaggedCommentsAction } from '../../../../../../utils/constants';
+import { FlaggedComments } from '../../../interfaces/flagged-comments.interface';
+
+/**
+ * Returns a list of available actions for a reported question based on its status.
+ */
+function getQuestionActions(status: number) {
+  const s = QuizRatingStatus;
+
+  const isFinalState = status === s.Accepted || status === s.Ignore;
+
+  // ---- Tooltip and Action helper logic ----
+
+  const getCheckTooltip = (): string => {
+    if (status === s.Accepted) return 'Already Accepted';
+    if (status === s.Ignore) return 'Already Ignored';
+    if (status === s.Pending) return 'Accept Report';
+    return 'Accept Report';
+  };
+
+  const getBlockTooltip = (): string => {
+    if (status === s.Accepted) return 'Already Accepted';
+    if (status === s.Ignore) return 'Already Ignored';
+    if (status === s.Pending) return 'Ignore Report';
+    return 'Ignore Report';
+  };
+
+  // ---- Build action list ----
+  return [
+    {
+      icon: flaggedCommentsAction.VIEW,
+      tooltip: 'View Details',
+      isDisabled: false,
+    },
+    {
+      icon: flaggedCommentsAction.ACCEPTED,
+      tooltip: getCheckTooltip(),
+      isDisabled: isFinalState,
+    },
+    {
+      icon: flaggedCommentsAction.IGNORED,
+      tooltip: getBlockTooltip(),
+      isDisabled: isFinalState,
+    },
+  ];
+}
+
+/**
+ * Maps a `Flagged Comments` object to a `TableData` object for the Reported Questions table.
+ */
+export function flaggedCommentsToTableData(comment: FlaggedComments): TableData {
+  const truncatedComment =
+    comment.comment!.length > 40 ? comment.comment!.slice(0, 40) + '…' : comment.comment;
+
+  return {
+    id: comment.id,
+    comment: truncatedComment,
+    author: comment.author,
+    quizName: comment.quizName,
+    reason: comment.reason,
+    date: new Date(comment.date).toLocaleDateString(),
+    status: {
+      tagConfig: {
+        id: comment.status.toString(),
+        label: getStatusLabel(comment.status),
+        type: 'static',
+        backgroundColor: getStatusColor(comment.status).bg,
+        textColor: getStatusColor(comment.status).text,
+      },
+    },
+    actions: getQuestionActions(comment.status),
+  };
+}
+
+/**
+ * Maps a numeric status to a readable label.
+ */
+export function getStatusLabel(status: number): string {
+  const s = QuizRatingStatus;
+  switch (status) {
+    case s.Accepted:
+      return 'Accepted';
+    case s.Ignore:
+      return 'Ignored';
+    case s.Pending:
+      return 'Pending';
+    case s.UnderProcessing:
+      return 'Under Processing';
+    default:
+      return 'Unknown';
+  }
+}
+
+/**
+ * Maps a numeric status to background and text colors.
+ */
+export function getStatusColor(status: number): { bg: string; text: string } {
+  const s = QuizRatingStatus;
+  switch (status) {
+    case QuizRatingStatus.Accepted:
+      return colors.green;
+    case QuizRatingStatus.Pending:
+      return colors.blue;
+    case QuizRatingStatus.Ignore:
+      return colors.red;
+    case QuizRatingStatus.UnderProcessing:
+      return colors.yellow;
+    default:
+      return colors.black;
+  }
+}

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments.component.html
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments.component.html
@@ -1,0 +1,32 @@
+<main>
+  <div class="admin-management-toolbar">
+    <section class="page-header">
+      <h2 class="page-title">Flagged Comments</h2>
+    </section>
+
+    <div class="user-management-filters">
+      <!-- Status Filter -->
+      <mat-form-field appearance="outline" class="filter-select">
+        <mat-select
+          [(value)]="selectedStatus"
+          (selectionChange)="onFilterChange()"
+          placeholder="All Status"
+        >
+          <mat-option [value]="''">All Status</mat-option>
+          @for (status of flaggedCommentStatus; track status.value) {
+            <mat-option [value]="status.value">{{ status.label }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    </div>
+  </div>
+
+  <app-flagged-comments-table
+    [dataSource]="dataSource()"
+    [totalItems]="totalItems()"
+    (pageChange)="onPageChange($event)"
+    (sortChange)="onSortChange($event)"
+    (actionClick)="handleFlaggedCommentAction($event)"
+  >
+  </app-flagged-comments-table>
+</main>

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments.component.scss
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments.component.scss
@@ -1,0 +1,130 @@
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  .page-title {
+    font-size: 20px;
+    font-weight: 600;
+    margin: 0;
+    color: #1e293b;
+  }
+
+  .page-description {
+    font-size: 14px;
+    color: #64748b;
+    margin: 0;
+  }
+}
+
+.admin-management-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 24px;
+  background-color: #ffffff;
+  border-radius: 10px;
+  margin-bottom: 0px;
+
+  .user-management-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+
+    .filter-select {
+      width: 220px; // default desktop width
+    }
+  }
+}
+
+@media (min-width: 1017px) and (max-width: 1200px) {
+  .admin-management-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+
+    .user-management-filters {
+      flex-direction: row;
+      width: 100%;
+      gap: 12px;
+
+      .filter-select {
+        width: 49%;
+      }
+    }
+  }
+}
+
+@media (max-width: 1024px) {
+  .admin-management-toolbar {
+    padding: 16px;
+  }
+}
+@media (min-width: 769px) and (max-width: 1016px) {
+  .admin-management-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+
+    .user-management-filters {
+      flex-direction: row;
+      width: 100%;
+      gap: 12px;
+
+      .filter-select {
+        width: 49%;
+      }
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .page-header {
+    align-items: flex-start;
+    text-align: left;
+
+    .page-title {
+      font-size: 20px;
+    }
+
+    .page-description {
+      font-size: 13px;
+    }
+  }
+
+  .admin-management-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+
+    .user-management-filters {
+      flex-direction: column;
+      width: 100%;
+
+      .filter-select {
+        width: 100%;
+      }
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .page-header {
+    .page-title {
+      font-size: 18px;
+    }
+
+    .page-description {
+      font-size: 12px;
+    }
+  }
+
+  .admin-management-toolbar {
+    padding: 12px;
+  }
+}

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments.component.spec.ts
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments.component.spec.ts
@@ -1,0 +1,426 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatSelectModule } from '@angular/material/select';
+import { of, throwError, Subject } from 'rxjs';
+import { FlaggedCommentsComponent } from './flagged-comments.component';
+import { FlaggedCommentsService } from '../../../../../services/admin/content-moderation/flagged-comments.service';
+import { SnackbarService } from '../../../../../shared/service/snackbar/snackbar.service';
+import { AuthService } from '../../../../../core/auth/services/auth.service';
+import { ConfirmationDialogComponent } from '../../../../../shared/components/confirmation-dialog/confirmation-dialog.component';
+import { FlaggedCommentsPreviewDialogComponent } from './flagged-comments-preview-dialog/flagged-comments-preview-dialog.component';
+import { FlaggedCommentsTableComponent } from './flagged-comments-table/flagged-comments-table.component';
+import { TableData } from '../../../../../shared/interfaces/table-component.interface';
+import { PaginationRequest } from '../../../../../shared/interfaces/pagination-request.interface';
+import {
+  flaggedCommentsAction,
+  platformMessages,
+  tablePaginationConfig,
+} from '../../../../../utils/constants';
+import {
+  FlaggedComments,
+  UpdateFlaggedCommentStatusRequest,
+} from '../../interfaces/flagged-comments.interface';
+import { QuizRatingStatus } from '../../../../../shared/enums/content-moderation.enum';
+
+// Mock services
+const mockFlaggedCommentsService = {
+  getFlaggedCommentsList: jest.fn(),
+  updateAction: jest.fn(),
+  flaggedCommentUpdated$: new Subject<boolean>(),
+};
+
+const mockSnackbarService = {
+  showSuccess: jest.fn(),
+  showError: jest.fn(),
+};
+
+const mockMatDialog = {
+  open: jest.fn(),
+};
+
+describe('FlaggedCommentsComponent', () => {
+  let component: FlaggedCommentsComponent;
+  let fixture: ComponentFixture<FlaggedCommentsComponent>;
+  let flaggedCommentsService: jest.Mocked<FlaggedCommentsService>;
+  let snackbarService: jest.Mocked<SnackbarService>;
+  let dialog: jest.Mocked<MatDialog>;
+
+  const mockFlaggedComments: FlaggedComments[] = [
+    {
+      id: 1,
+      comment: 'Test comment 1',
+      status: QuizRatingStatus.Pending,
+      date: new Date(),
+      author: 'User1',
+      quizName: 'Quiz1',
+      reason: 'Inappropriate content',
+      modifiedBy: 1,
+    },
+    {
+      id: 2,
+      comment: 'Test comment 2',
+      status: QuizRatingStatus.Pending,
+      date: new Date(),
+      author: 'User2',
+      quizName: 'Quiz2',
+      reason: 'Inappropriate content',
+      modifiedBy: 1,
+    },
+  ];
+
+  const mockTableData: TableData[] = [
+    { id: 1, comment: 'Test comment 1', status: 'Pending' },
+    { id: 2, comment: 'Test comment 2', status: 'Pending' },
+  ];
+
+  const mockApiResponse = {
+    result: true,
+    statusCode: 200,
+    message: 'Success',
+    data: {
+      records: mockFlaggedComments,
+      totalRecords: 2,
+    },
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FlaggedCommentsComponent, MatDialogModule, MatSelectModule],
+      providers: [
+        { provide: FlaggedCommentsService, useValue: mockFlaggedCommentsService },
+        { provide: SnackbarService, useValue: mockSnackbarService },
+        { provide: MatDialog, useValue: mockMatDialog },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FlaggedCommentsComponent);
+    component = fixture.componentInstance;
+
+    flaggedCommentsService = TestBed.inject(
+      FlaggedCommentsService,
+    ) as jest.Mocked<FlaggedCommentsService>;
+    snackbarService = TestBed.inject(SnackbarService) as jest.Mocked<SnackbarService>;
+    dialog = TestBed.inject(MatDialog) as jest.Mocked<MatDialog>;
+
+    // Reset all mocks
+    jest.clearAllMocks();
+    mockFlaggedCommentsService.flaggedCommentUpdated$ = new Subject<boolean>();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Initialization', () => {
+    it('should initialize with default values', () => {
+      expect(component.dataSource()).toEqual([]);
+      expect(component.totalItems()).toBe(0);
+      expect(component.pagination()).toEqual({
+        pageNumber: 1,
+        pageSize: tablePaginationConfig.PageSize,
+      });
+      expect(component.sort()).toEqual({
+        sortColumn: '',
+        sortDescending: false,
+      });
+    });
+
+    it('should call getFlaggedCommentsData on init', () => {
+      const getDataSpy = jest.spyOn(component as any, 'getFlaggedCommmentsData');
+      flaggedCommentsService.getFlaggedCommentsList.mockReturnValue(of(mockApiResponse));
+
+      component.ngOnInit();
+
+      expect(getDataSpy).toHaveBeenCalled();
+    });
+
+    it('should subscribe to flaggedCommentUpdated$ and refresh data when updated', () => {
+      const getDataSpy = jest.spyOn(component as any, 'getFlaggedCommmentsData');
+      flaggedCommentsService.getFlaggedCommentsList.mockReturnValue(of(mockApiResponse));
+
+      component.ngOnInit();
+
+      // Simulate update event
+      flaggedCommentsService.flaggedCommentUpdated$.next(true);
+
+      expect(getDataSpy).toHaveBeenCalledTimes(2); // Once on init, once on update
+      expect(flaggedCommentsService.flaggedCommentUpdated$.next).toBeDefined();
+    });
+  });
+
+  describe('Pagination and Sorting', () => {
+    beforeEach(() => {
+      flaggedCommentsService.getFlaggedCommentsList.mockReturnValue(of(mockApiResponse));
+    });
+
+    it('should handle page change', () => {
+      const getDataSpy = jest.spyOn(component as any, 'getFlaggedCommmentsData');
+      const pageEvent = { pageIndex: 1, pageSize: 20 };
+
+      component.onPageChange(pageEvent);
+
+      expect(component.pagination()).toEqual({
+        pageNumber: 2,
+        pageSize: 20,
+      });
+      expect(getDataSpy).toHaveBeenCalled();
+    });
+
+    it('should handle sort change', () => {
+      const getDataSpy = jest.spyOn(component as any, 'getFlaggedCommmentsData');
+      const sortEvent = { active: 'comment', direction: 'desc' };
+
+      component.onSortChange(sortEvent);
+
+      expect(component.sort()).toEqual({
+        sortColumn: 'comment',
+        sortDescending: true,
+      });
+      expect(getDataSpy).toHaveBeenCalled();
+    });
+
+    it('should handle filter change and reset to first page', () => {
+      const getDataSpy = jest.spyOn(component as any, 'getFlaggedCommmentsData');
+
+      // Set current page to something other than 1
+      component.pagination.set({ pageNumber: 3, pageSize: 10 });
+
+      component.onFilterChange();
+
+      expect(component.pagination().pageNumber).toBe(1);
+      expect(getDataSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Flagged Comment Actions', () => {
+    const mockTableRow: TableData = { id: 1, comment: 'Test comment', status: 'Pending' };
+
+    beforeEach(() => {
+      flaggedCommentsService.getFlaggedCommentsList.mockReturnValue(of(mockApiResponse));
+      dialog.open.mockReturnValue({
+        afterClosed: () => of(true),
+      } as any);
+    });
+
+    it('should handle VIEW action and open preview dialog', () => {
+      const loadPreviewSpy = jest.spyOn(component, 'loadFlaggedCommentPreview');
+
+      component.handleFlaggedCommentAction({
+        action: flaggedCommentsAction.VIEW,
+        row: mockTableRow,
+      });
+
+      expect(loadPreviewSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle ACCEPTED action and open confirmation dialog', () => {
+      const openDialogSpy = jest.spyOn(component, 'openConfirmationDialog');
+
+      component.handleFlaggedCommentAction({
+        action: flaggedCommentsAction.ACCEPTED,
+        row: mockTableRow,
+      });
+
+      expect(openDialogSpy).toHaveBeenCalled();
+    });
+
+    it('should handle IGNORED action and open confirmation dialog', () => {
+      const openDialogSpy = jest.spyOn(component, 'openConfirmationDialog');
+
+      component.handleFlaggedCommentAction({
+        action: flaggedCommentsAction.IGNORED,
+        row: mockTableRow,
+      });
+
+      expect(openDialogSpy).toHaveBeenCalled();
+    });
+
+    it('should not do anything for unknown action', () => {
+      const consoleSpy = jest.spyOn(console, 'warn');
+
+      component.handleFlaggedCommentAction({
+        action: 'UNKNOWN_ACTION',
+        row: mockTableRow,
+      });
+
+      // Should not throw error or call any service
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Confirmation Dialog', () => {
+    it('should open confirmation dialog and execute onConfirm when confirmed', () => {
+      const mockOnConfirm = jest.fn();
+      const mockDialogRef = {
+        afterClosed: () => of(true),
+      };
+      dialog.open.mockReturnValue(mockDialogRef as any);
+
+      component.openConfirmationDialog({ title: 'Test' } as any, mockOnConfirm);
+
+      expect(dialog.open).toHaveBeenCalledWith(ConfirmationDialogComponent, {
+        width: '600px',
+        disableClose: false,
+        data: { title: 'Test' },
+        panelClass: 'custom-dialog-radius',
+      });
+
+      // The callback should be called when dialog returns true
+      expect(mockOnConfirm).toHaveBeenCalled();
+    });
+
+    it('should not execute onConfirm when dialog is cancelled', () => {
+      const mockOnConfirm = jest.fn();
+      const mockDialogRef = {
+        afterClosed: () => of(false),
+      };
+      dialog.open.mockReturnValue(mockDialogRef as any);
+
+      component.openConfirmationDialog({ title: 'Test' } as any, mockOnConfirm);
+
+      expect(mockOnConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Update Comment Status', () => {
+    const mockPayload: UpdateFlaggedCommentStatusRequest = {
+      id: 1,
+      status: QuizRatingStatus.Accepted,
+    };
+
+    it('should successfully update comment status', () => {
+      const successResponse = {
+        result: true,
+        statusCode: 200,
+        message: 'Status updated successfully',
+        data: null,
+      };
+      flaggedCommentsService.updateAction.mockReturnValue(of(successResponse));
+      const getDataSpy = jest.spyOn(component as any, 'getFlaggedCommmentsData');
+
+      component.updateQueReportStatus(1, QuizRatingStatus.Accepted);
+
+      expect(flaggedCommentsService.updateAction).toHaveBeenCalledWith(mockPayload);
+      expect(snackbarService.showSuccess).toHaveBeenCalledWith(
+        platformMessages.successTitle,
+        successResponse.message,
+      );
+      expect(getDataSpy).toHaveBeenCalled();
+    });
+
+    it('should handle update failure', () => {
+      const errorResponse = {
+        result: false,
+        statusCode: 400,
+        message: 'Update failed',
+        data: null,
+      };
+      flaggedCommentsService.updateAction.mockReturnValue(of(errorResponse));
+
+      component.updateQueReportStatus(1, QuizRatingStatus.Accepted);
+
+      expect(snackbarService.showError).toHaveBeenCalledWith(
+        platformMessages.errorTitle,
+        errorResponse.message,
+      );
+    });
+
+    it('should handle update error', () => {
+      const mockError = { error: { message: 'Server error' } };
+      flaggedCommentsService.updateAction.mockReturnValue(throwError(() => mockError));
+
+      component.updateQueReportStatus(1, QuizRatingStatus.Accepted);
+
+      expect(snackbarService.showError).toHaveBeenCalledWith(
+        platformMessages.errorTitle,
+        'Server error',
+      );
+    });
+  });
+
+  describe('Load Flagged Comment Preview', () => {
+    it('should open preview dialog with correct parameters', () => {
+      component.loadFlaggedCommentPreview(1);
+
+      expect(dialog.open).toHaveBeenCalledWith(FlaggedCommentsPreviewDialogComponent, {
+        width: '600px',
+        maxHeight: '80vh',
+        data: 1,
+      });
+    });
+  });
+
+  describe('Data Fetching', () => {
+    it('should fetch flagged comments data successfully', fakeAsync(() => {
+      flaggedCommentsService.getFlaggedCommentsList.mockReturnValue(of(mockApiResponse));
+
+      (component as any).getFlaggedCommmentsData();
+
+      tick();
+
+      expect(flaggedCommentsService.getFlaggedCommentsList).toHaveBeenCalled();
+      expect(component.dataSource().length).toBe(2);
+      expect(component.totalItems()).toBe(2);
+    }));
+
+    it('should handle API error when fetching data', () => {
+      const mockError = { error: { message: 'Server error' } };
+      flaggedCommentsService.getFlaggedCommentsList.mockReturnValue(throwError(() => mockError));
+
+      (component as any).getFlaggedCommmentsData();
+
+      expect(snackbarService.showError).toHaveBeenCalledWith(
+        platformMessages.errorTitle,
+        'Server error',
+      );
+    });
+
+    it('should apply status filter when selected', () => {
+      component.selectedStatus = QuizRatingStatus.Pending;
+      flaggedCommentsService.getFlaggedCommentsList.mockReturnValue(of(mockApiResponse));
+
+      (component as any).getFlaggedCommmentsData();
+
+      const expectedRequest: PaginationRequest = {
+        ...component.pagination(),
+        searchTerm: '',
+        sortColumn: component.sort().sortColumn,
+        sortDescending: component.sort().sortDescending,
+        filters: {
+          commentStatus: QuizRatingStatus.Pending,
+        },
+      };
+
+      expect(flaggedCommentsService.getFlaggedCommentsList).toHaveBeenCalledWith(expectedRequest);
+    });
+  });
+
+  describe('Cleanup', () => {
+    it('should complete destroy$ on ngOnDestroy', () => {
+      const nextSpy = jest.spyOn(component['destroy$'], 'next');
+      const completeSpy = jest.spyOn(component['destroy$'], 'complete');
+
+      component.ngOnDestroy();
+
+      expect(nextSpy).toHaveBeenCalledWith();
+      expect(completeSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Flagged Comment Status Options', () => {
+    it('should have correct flagged comment status options', () => {
+      expect(component.flaggedCommentStatus).toBeDefined();
+      expect(Array.isArray(component.flaggedCommentStatus)).toBe(true);
+
+      // Should filter out numeric keys and only keep string keys
+      component.flaggedCommentStatus.forEach((option) => {
+        expect(option).toHaveProperty('label');
+        expect(option).toHaveProperty('value');
+        expect(typeof option.label).toBe('string');
+        expect(typeof option.value).toBe('number');
+      });
+    });
+  });
+});

--- a/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments.component.ts
+++ b/src/app/pages/admin/content-moderation/components/flagged-comments/flagged-comments.component.ts
@@ -1,0 +1,202 @@
+import { Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
+import { MatSelectModule } from '@angular/material/select';
+import { FlaggedCommentsTableComponent } from './flagged-comments-table/flagged-comments-table.component';
+import { MatDialog } from '@angular/material/dialog';
+import { Subject, takeUntil } from 'rxjs';
+import { SnackbarService } from '../../../../../shared/service/snackbar/snackbar.service';
+import { FlaggedCommentsService } from '../../../../../services/admin/content-moderation/flagged-comments.service';
+import { TableData } from '../../../../../shared/interfaces/table-component.interface';
+import {
+  flaggedCommentsAction,
+  platformMessages,
+  tablePaginationConfig,
+} from '../../../../../utils/constants';
+import { QuizRatingStatus } from '../../../../../shared/enums/content-moderation.enum';
+import { PaginationRequest } from '../../../../../shared/interfaces/pagination-request.interface';
+import {
+  FlaggedComments,
+  UpdateFlaggedCommentStatusRequest,
+} from '../../interfaces/flagged-comments.interface';
+import { flaggedCommentsToTableData } from './flagged-comments-table/flagged-comments-table.mapper';
+import { ConfirmationDialogData } from '../../../../../shared/interfaces/confirmation-dialog.interface';
+import { ConfirmationDialogComponent } from '../../../../../shared/components/confirmation-dialog/confirmation-dialog.component';
+import {
+  acceptedDialog,
+  ignoredDialog,
+} from '../../configs/flagged-comment-confirmation-dialog.config';
+import { FlaggedCommentsPreviewDialogComponent } from './flagged-comments-preview-dialog/flagged-comments-preview-dialog.component';
+
+@Component({
+  selector: 'app-flagged-comments',
+  imports: [MatSelectModule, FlaggedCommentsTableComponent],
+  templateUrl: './flagged-comments.component.html',
+  styleUrl: './flagged-comments.component.scss',
+})
+export class FlaggedCommentsComponent implements OnInit, OnDestroy {
+  dialog = inject(MatDialog);
+
+  //filters
+  selectedStatus: number;
+  selectedSeverity: number;
+
+  // Table data
+  dataSource = signal<TableData[]>([]);
+  totalItems = signal(0);
+  pagination = signal({ pageNumber: 1, pageSize: tablePaginationConfig.PageSize });
+  sort = signal({ sortColumn: '', sortDescending: false });
+
+  flaggedCommentStatus = Object.keys(QuizRatingStatus)
+    .filter((key) => Number.isNaN(Number(key)))
+    .map((key) => ({
+      label: key,
+      value: QuizRatingStatus[key as keyof typeof QuizRatingStatus],
+    }));
+
+  private readonly destroy$ = new Subject<void>();
+  private readonly snackbar = inject(SnackbarService);
+  private readonly flaggedCommentservice = inject(FlaggedCommentsService);
+
+  ngOnInit(): void {
+    this.getFlaggedCommmentsData();
+
+    this.flaggedCommentservice.flaggedCommentUpdated$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((updated) => {
+        if (updated) {
+          this.getFlaggedCommmentsData();
+          this.flaggedCommentservice.flaggedCommentUpdated$.next(false);
+        }
+      });
+  }
+
+  onPageChange(event: { pageIndex: number; pageSize: number }) {
+    this.pagination.set({ pageNumber: event.pageIndex + 1, pageSize: event.pageSize });
+    this.getFlaggedCommmentsData();
+  }
+
+  onSortChange(event: { active: string; direction: string }) {
+    this.sort.set({
+      sortColumn: event.active,
+      sortDescending: event.direction === 'desc',
+    });
+    this.getFlaggedCommmentsData();
+  }
+
+  onFilterChange() {
+    this.pagination.set({ ...this.pagination(), pageNumber: 1 });
+    this.getFlaggedCommmentsData();
+  }
+
+  handleFlaggedCommentAction(event: { action: string; row: TableData }): void {
+    const comment = event.row;
+
+    switch (event.action) {
+      case flaggedCommentsAction.VIEW: {
+        this.loadFlaggedCommentPreview(Number(comment['id']));
+        break;
+      }
+      case flaggedCommentsAction.ACCEPTED:
+        this.openConfirmationDialog(acceptedDialog, () =>
+          this.updateQueReportStatus(comment['id'] as number, QuizRatingStatus.Accepted),
+        );
+        break;
+      case flaggedCommentsAction.IGNORED:
+        this.openConfirmationDialog(ignoredDialog, () =>
+          this.updateQueReportStatus(comment['id'] as number, QuizRatingStatus.Ignore),
+        );
+        break;
+    }
+  }
+
+  openConfirmationDialog(dialogData: ConfirmationDialogData, onConfirm: () => void): void {
+    const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
+      width: '600px',
+      disableClose: false,
+      data: dialogData,
+      panelClass: 'custom-dialog-radius',
+    });
+
+    dialogRef.afterClosed().subscribe((confirmed) => {
+      if (confirmed) onConfirm();
+    });
+  }
+
+  updateQueReportStatus(commentId: number, newStatus: QuizRatingStatus): void {
+    const payload: UpdateFlaggedCommentStatusRequest = {
+      id: commentId,
+      status: newStatus,
+    };
+    this.flaggedCommentservice
+      .updateAction(payload)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          if (res.result && res.statusCode === 200) {
+            this.snackbar.showSuccess(platformMessages.successTitle, res.message);
+            this.getFlaggedCommmentsData();
+          } else {
+            this.snackbar.showError(platformMessages.errorTitle, res.message);
+          }
+        },
+        error: (err) =>
+          this.snackbar.showError(
+            platformMessages.errorTitle,
+            err?.error?.message || platformMessages.errorMessage,
+          ),
+      });
+  }
+
+  loadFlaggedCommentPreview(commentId: number) {
+    this.dialog.open(FlaggedCommentsPreviewDialogComponent, {
+      width: '600px',
+      maxHeight: '80vh',
+      data: commentId,
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private getFlaggedCommmentsData(): void {
+    const request: PaginationRequest = {
+      ...this.pagination(),
+      searchTerm: '',
+      sortColumn: this.sort().sortColumn,
+      sortDescending: this.sort().sortDescending,
+      filters: {},
+    };
+
+    // Filter by severity
+    if (this.selectedStatus) request.filters!['commentStatus'] = Number(this.selectedStatus);
+    this.flaggedCommentservice
+      .getFlaggedCommentsList(request)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          if (!res.result || res.statusCode !== 200) {
+            this.snackbar.showError(
+              res.message || platformMessages.errorMessage,
+              `${platformMessages.errorTitle} ${res.statusCode}`,
+            );
+            this.dataSource.set([]);
+            this.totalItems.set(0);
+          }
+          const tableData = res.data.records.map((comment: FlaggedComments) =>
+            flaggedCommentsToTableData(comment),
+          );
+
+          // Set data for your table
+          this.dataSource.set(tableData);
+          this.totalItems.set(res.data.totalRecords);
+        },
+        error: (err) => {
+          this.snackbar.showError(
+            platformMessages.errorTitle,
+            err?.error?.message || platformMessages.errorMessage,
+          );
+        },
+      });
+  }
+}

--- a/src/app/pages/admin/content-moderation/configs/flagged-comment-confirmation-dialog.config.ts
+++ b/src/app/pages/admin/content-moderation/configs/flagged-comment-confirmation-dialog.config.ts
@@ -1,0 +1,53 @@
+import { ButtonConfig } from '../../../../shared/interfaces/button-config.interface';
+import { ConfirmationDialogData } from '../../../../shared/interfaces/confirmation-dialog.interface';
+
+export const cancelButtonConfig: ButtonConfig = {
+  label: 'Cancel',
+  variant: 'secondary',
+};
+
+export const closeButtonConfig: ButtonConfig = {
+  label: 'Close',
+  variant: 'secondary',
+};
+
+export const ignoreButtonConfig: ButtonConfig = {
+  label: 'Ignore Report',
+  variant: 'secondary',
+};
+
+export const acceptReportButtonConfig: ButtonConfig = {
+  label: 'Accept Report',
+  variant: 'secondary',
+};
+
+export const acceptReportForDialogButtonConfig: ButtonConfig = {
+  label: 'Accept',
+  variant: 'primary',
+  matIcon: 'check_circle',
+  imagePosition: 'left',
+  iconFontSet: 'material-icons-outlined',
+};
+
+export const ignoreReportForDialogButtonConfig: ButtonConfig = {
+  label: 'Ignore',
+  variant: 'secondary',
+  matIcon: 'block',
+  imagePosition: 'left',
+  iconFontSet: 'material-icons-outlined',
+};
+
+export const acceptedDialog: ConfirmationDialogData = {
+  title: 'Accept Report',
+  message:
+    'Are you sure you want to accept this report? This action cannot be undone and this comment will not be shown again in the quiz comment section.',
+  confirmButtonConfig: acceptReportButtonConfig,
+  cancelButtonConfig: cancelButtonConfig,
+};
+
+export const ignoredDialog: ConfirmationDialogData = {
+  title: 'Ignore Report',
+  message: 'Do you want to ignore this report? It will be closed without any further review.',
+  confirmButtonConfig: ignoreButtonConfig,
+  cancelButtonConfig: cancelButtonConfig,
+};

--- a/src/app/pages/admin/content-moderation/configs/flagged-comments-table.config.ts
+++ b/src/app/pages/admin/content-moderation/configs/flagged-comments-table.config.ts
@@ -1,0 +1,54 @@
+import { ColumnDef } from '../../../../shared/interfaces/table-component.interface';
+import { tablePaginationConfig } from '../../../../utils/constants';
+
+//#region Table Configuration
+export const flaggedCommentsTableColumnsConfig: ColumnDef[] = [
+  {
+    key: 'comment',
+    label: 'Comments',
+    type: 'text',
+    isSortable: true,
+  },
+  {
+    key: 'author',
+    label: 'Author',
+    type: 'text',
+    isSortable: true,
+  },
+  {
+    key: 'quizName',
+    label: 'Quiz Name',
+    type: 'text',
+    isSortable: true,
+  },
+  {
+    key: 'reason',
+    label: 'Reason',
+    type: 'text',
+    isSortable: true,
+  },
+  {
+    key: 'date',
+    label: 'Date',
+    type: 'text',
+    isSortable: true,
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    type: 'tag',
+    isSortable: true,
+  },
+  {
+    key: 'actions',
+    label: 'Actions',
+    type: 'button',
+    isSortable: false,
+  },
+];
+
+export const flaggedCommentsTablePaginationConfig = {
+  pageSize: tablePaginationConfig.PageSize,
+  pageSizeOptions: tablePaginationConfig.PageSizeOptions,
+  applyPaginator: true,
+};

--- a/src/app/pages/admin/content-moderation/interfaces/flagged-comments.interface.ts
+++ b/src/app/pages/admin/content-moderation/interfaces/flagged-comments.interface.ts
@@ -1,0 +1,20 @@
+export interface FlaggedComments {
+  id: number;
+  comment?: string;
+  author: string;
+  quizName: string;
+  reason?: string;
+  date: Date;
+  status: number;
+  modifiedBy?: number;
+}
+
+export interface FlaggedCommentView extends FlaggedComments {
+  quizCategory: string;
+  userId: number;
+}
+
+export interface UpdateFlaggedCommentStatusRequest {
+  id: number;
+  status: number;
+}

--- a/src/app/services/admin/content-moderation/flagged-comments.service.spec.ts
+++ b/src/app/services/admin/content-moderation/flagged-comments.service.spec.ts
@@ -1,0 +1,414 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { FlaggedCommentsService } from './flagged-comments.service';
+import { environment } from '../../../../environments/environment.dev';
+import { EndPoints } from '../../../shared/enums/end-point.enum';
+import { skipLoader } from '../../../utils/constants';
+import { PaginationRequest } from '../../../shared/interfaces/pagination-request.interface';
+import {
+  FlaggedComments,
+  FlaggedCommentView,
+  UpdateFlaggedCommentStatusRequest,
+} from '../../../pages/admin/content-moderation/interfaces/flagged-comments.interface';
+
+describe('FlaggedCommentsService', () => {
+  let service: FlaggedCommentsService;
+  let httpMock: HttpTestingController;
+
+  const mockPaginationRequest: PaginationRequest = {
+    pageNumber: 1,
+    pageSize: 10,
+    searchTerm: '',
+    sortColumn: 'date',
+    sortDescending: false,
+    filters: {},
+  };
+
+  const mockFlaggedComments: FlaggedComments[] = [
+    {
+      id: 1,
+      comment: 'Test comment 1',
+      author: 'User 1',
+      quizName: 'Quiz 1',
+      reason: 'Spam',
+      date: new Date('2023-01-01'),
+      status: 1,
+      modifiedBy: 123,
+    },
+    {
+      id: 2,
+      comment: 'Test comment 2',
+      author: 'User 2',
+      quizName: 'Quiz 2',
+      reason: 'Inappropriate',
+      date: new Date('2023-01-02'),
+      status: 2,
+      modifiedBy: 124,
+    },
+  ];
+
+  const mockFlaggedCommentView: FlaggedCommentView = {
+    id: 1,
+    comment: 'Test comment',
+    author: 'Test User',
+    quizName: 'Test Quiz',
+    reason: 'Spam',
+    date: new Date('2023-01-01'),
+    status: 1,
+    modifiedBy: 123,
+    quizCategory: 'Education',
+    userId: 456,
+  };
+
+  const mockUpdateRequest: UpdateFlaggedCommentStatusRequest = {
+    id: 1,
+    status: 2,
+  };
+
+  const mockApiResponse = {
+    result: true,
+    statusCode: 200,
+    message: 'Success',
+    data: {
+      records: mockFlaggedComments,
+      totalRecords: 2,
+    },
+  };
+
+  const mockUpdateResponse = {
+    result: true,
+    statusCode: 200,
+    message: 'Updated successfully',
+    data: null,
+  };
+
+  const mockPreviewResponse = {
+    result: true,
+    statusCode: 200,
+    message: 'Success',
+    data: mockFlaggedCommentView,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [FlaggedCommentsService],
+    });
+
+    service = TestBed.inject(FlaggedCommentsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('Service Creation', () => {
+    it('should be created', () => {
+      expect(service).toBeTruthy();
+    });
+
+    it('should have flaggedCommentUpdated$ BehaviorSubject', () => {
+      expect(service.flaggedCommentUpdated$).toBeTruthy();
+      expect(service.flaggedCommentUpdated$.value).toBe(false);
+    });
+  });
+
+  describe('getFlaggedCommentsList', () => {
+    it('should fetch flagged comments list with POST request', () => {
+      service.getFlaggedCommentsList(mockPaginationRequest).subscribe((response) => {
+        expect(response).toEqual(mockApiResponse);
+        expect(response.data.records.length).toBe(2);
+        expect(response.data.records[0].id).toBe(1);
+        expect(response.data.records[1].id).toBe(2);
+      });
+
+      const req = httpMock.expectOne(`${environment.baseUrl}/${EndPoints.FlaggedContentList}`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(mockPaginationRequest);
+
+      req.flush(mockApiResponse);
+    });
+
+    it('should handle empty response', () => {
+      const emptyResponse = {
+        result: true,
+        statusCode: 200,
+        message: 'No data',
+        data: {
+          records: [],
+          totalRecords: 0,
+        },
+      };
+
+      service.getFlaggedCommentsList(mockPaginationRequest).subscribe((response) => {
+        expect(response.data.records).toEqual([]);
+        expect(response.data.totalRecords).toBe(0);
+      });
+
+      const req = httpMock.expectOne(`${environment.baseUrl}/${EndPoints.FlaggedContentList}`);
+      req.flush(emptyResponse);
+    });
+
+    it('should handle error response', () => {
+      const errorResponse = {
+        result: false,
+        statusCode: 500,
+        message: 'Internal server error',
+        data: null,
+      };
+
+      service.getFlaggedCommentsList(mockPaginationRequest).subscribe((response) => {
+        expect(response.result).toBe(false);
+        expect(response.statusCode).toBe(500);
+        expect(response.message).toBe('Internal server error');
+      });
+
+      const req = httpMock.expectOne(`${environment.baseUrl}/${EndPoints.FlaggedContentList}`);
+      req.flush(errorResponse);
+    });
+
+    it('should use the correct endpoint', () => {
+      service.getFlaggedCommentsList(mockPaginationRequest).subscribe();
+
+      const req = httpMock.expectOne(`${environment.baseUrl}/${EndPoints.FlaggedContentList}`);
+      expect(req.request.url).toBe(`${environment.baseUrl}/${EndPoints.FlaggedContentList}`);
+    });
+  });
+
+  describe('updateAction', () => {
+    it('should update flagged comment status with PUT request', () => {
+      service.updateAction(mockUpdateRequest).subscribe((response) => {
+        expect(response).toEqual(mockUpdateResponse);
+        expect(response.statusCode).toBe(200);
+        expect(response.message).toBe('Updated successfully');
+      });
+
+      const req = httpMock.expectOne(
+        `${environment.baseUrl}/${EndPoints.ManageFlaggedCommentStatus}`,
+      );
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual(mockUpdateRequest);
+
+      req.flush(mockUpdateResponse);
+    });
+
+    it('should handle update failure', () => {
+      const errorResponse = {
+        result: false,
+        statusCode: 400,
+        message: 'Bad request',
+        data: null,
+      };
+
+      service.updateAction(mockUpdateRequest).subscribe((response) => {
+        expect(response.result).toBe(false);
+        expect(response.statusCode).toBe(400);
+      });
+
+      const req = httpMock.expectOne(
+        `${environment.baseUrl}/${EndPoints.ManageFlaggedCommentStatus}`,
+      );
+      req.flush(errorResponse);
+    });
+
+    it('should use the correct endpoint for update', () => {
+      service.updateAction(mockUpdateRequest).subscribe();
+
+      const req = httpMock.expectOne(
+        `${environment.baseUrl}/${EndPoints.ManageFlaggedCommentStatus}`,
+      );
+      expect(req.request.url).toBe(
+        `${environment.baseUrl}/${EndPoints.ManageFlaggedCommentStatus}`,
+      );
+    });
+  });
+
+  describe('getFlaggedCommentsPreviewById', () => {
+    it('should fetch flagged comment preview by ID with GET request', () => {
+      const commentId = 1;
+
+      service.getFlaggedCommentsPreviewById(commentId).subscribe((response) => {
+        expect(response).toEqual(mockPreviewResponse);
+        expect(response.data.id).toBe(1);
+        expect(response.data.quizCategory).toBe('Education');
+        expect(response.data.userId).toBe(456);
+      });
+
+      const req = httpMock.expectOne(
+        `${environment.baseUrl}/${EndPoints.FlaggedCommentsById}/${commentId}`,
+      );
+      expect(req.request.method).toBe('GET');
+
+      // Check skipLoader header
+      expect(req.request.headers.get(skipLoader)).toBe('true');
+
+      req.flush(mockPreviewResponse);
+    });
+
+    it('should include skipLoader header in the request', () => {
+      const commentId = 1;
+
+      service.getFlaggedCommentsPreviewById(commentId).subscribe();
+
+      const req = httpMock.expectOne(
+        `${environment.baseUrl}/${EndPoints.FlaggedCommentsById}/${commentId}`,
+      );
+
+      const headers = req.request.headers;
+      expect(headers.get(skipLoader)).toBe('true');
+      expect(headers.has(skipLoader)).toBe(true);
+    });
+
+    it('should handle different comment IDs', () => {
+      const commentId = 999;
+
+      service.getFlaggedCommentsPreviewById(commentId).subscribe();
+
+      const req = httpMock.expectOne(
+        `${environment.baseUrl}/${EndPoints.FlaggedCommentsById}/${commentId}`,
+      );
+      expect(req.request.url).toBe(
+        `${environment.baseUrl}/${EndPoints.FlaggedCommentsById}/${commentId}`,
+      );
+
+      req.flush(mockPreviewResponse);
+    });
+
+    it('should handle preview not found', () => {
+      const commentId = 999;
+      const notFoundResponse = {
+        result: false,
+        statusCode: 404,
+        message: 'Comment not found',
+        data: null,
+      };
+
+      service.getFlaggedCommentsPreviewById(commentId).subscribe((response) => {
+        expect(response.result).toBe(false);
+        expect(response.statusCode).toBe(404);
+      });
+
+      const req = httpMock.expectOne(
+        `${environment.baseUrl}/${EndPoints.FlaggedCommentsById}/${commentId}`,
+      );
+      req.flush(notFoundResponse);
+    });
+  });
+
+  describe('notifyFlaggedCommentUpdated', () => {
+    it('should update flaggedCommentUpdated$ BehaviorSubject to true', () => {
+      // Initial value should be false
+      expect(service.flaggedCommentUpdated$.value).toBe(false);
+
+      service.notifyFlaggedCommentUpdated();
+
+      // Value should be updated to true
+      expect(service.flaggedCommentUpdated$.value).toBe(true);
+    });
+
+    it('should emit new value to subscribers', () => {
+      const emittedValues: boolean[] = [];
+
+      service.flaggedCommentUpdated$.subscribe((value) => {
+        emittedValues.push(value);
+      });
+
+      // Initial emission
+      expect(emittedValues).toEqual([false]);
+
+      service.notifyFlaggedCommentUpdated();
+
+      // Should emit true
+      expect(emittedValues).toEqual([false, true]);
+
+      service.notifyFlaggedCommentUpdated();
+
+      // Should emit true again
+      expect(emittedValues).toEqual([false, true, true]);
+    });
+  });
+
+  describe('HTTP Error Handling', () => {
+    it('should handle HTTP errors for getFlaggedCommentsList', () => {
+      const errorMessage = 'Http failure response for test: 500 Internal Server Error';
+
+      service.getFlaggedCommentsList(mockPaginationRequest).subscribe({
+        next: () => fail('should have failed with the network error'),
+        error: (error) => {
+          expect(error.status).toBe(500);
+          expect(error.statusText).toBe('Internal Server Error');
+        },
+      });
+
+      const req = httpMock.expectOne(`${environment.baseUrl}/${EndPoints.FlaggedContentList}`);
+      req.flush(errorMessage, { status: 500, statusText: 'Internal Server Error' });
+    });
+
+    it('should handle HTTP errors for updateAction', () => {
+      service.updateAction(mockUpdateRequest).subscribe({
+        next: () => fail('should have failed with the network error'),
+        error: (error) => {
+          expect(error.status).toBe(400);
+        },
+      });
+
+      const req = httpMock.expectOne(
+        `${environment.baseUrl}/${EndPoints.ManageFlaggedCommentStatus}`,
+      );
+      req.flush('Bad Request', { status: 400, statusText: 'Bad Request' });
+    });
+
+    it('should handle HTTP errors for getFlaggedCommentsPreviewById', () => {
+      const commentId = 1;
+
+      service.getFlaggedCommentsPreviewById(commentId).subscribe({
+        next: () => fail('should have failed with the network error'),
+        error: (error) => {
+          expect(error.status).toBe(404);
+        },
+      });
+
+      const req = httpMock.expectOne(
+        `${environment.baseUrl}/${EndPoints.FlaggedCommentsById}/${commentId}`,
+      );
+      req.flush('Not Found', { status: 404, statusText: 'Not Found' });
+    });
+  });
+
+  describe('Endpoint Construction', () => {
+    it('should construct correct URLs with baseUrl from environment', () => {
+      service.getFlaggedCommentsList(mockPaginationRequest).subscribe();
+
+      const req = httpMock.expectOne(`${environment.baseUrl}/${EndPoints.FlaggedContentList}`);
+      expect(req.request.url).toContain(environment.baseUrl);
+      expect(req.request.url).toContain(EndPoints.FlaggedContentList);
+
+      req.flush(mockApiResponse);
+    });
+
+    it('should use correct HTTP methods for each endpoint', () => {
+      // Test POST for getFlaggedCommentsList
+      service.getFlaggedCommentsList(mockPaginationRequest).subscribe();
+      const postReq = httpMock.expectOne(`${environment.baseUrl}/${EndPoints.FlaggedContentList}`);
+      expect(postReq.request.method).toBe('POST');
+      postReq.flush(mockApiResponse);
+
+      // Test PUT for updateAction
+      service.updateAction(mockUpdateRequest).subscribe();
+      const putReq = httpMock.expectOne(
+        `${environment.baseUrl}/${EndPoints.ManageFlaggedCommentStatus}`,
+      );
+      expect(putReq.request.method).toBe('PUT');
+      putReq.flush(mockUpdateResponse);
+
+      // Test GET for getFlaggedCommentsPreviewById
+      service.getFlaggedCommentsPreviewById(1).subscribe();
+      const getReq = httpMock.expectOne(
+        `${environment.baseUrl}/${EndPoints.FlaggedCommentsById}/1`,
+      );
+      expect(getReq.request.method).toBe('GET');
+      getReq.flush(mockPreviewResponse);
+    });
+  });
+});

--- a/src/app/services/admin/content-moderation/flagged-comments.service.ts
+++ b/src/app/services/admin/content-moderation/flagged-comments.service.ts
@@ -1,0 +1,55 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { PaginationRequest } from '../../../shared/interfaces/pagination-request.interface';
+import { BehaviorSubject, map, Observable } from 'rxjs';
+import { ApiResponse } from '../../../shared/interfaces/api-response.interface';
+import { PaginatedDataResponse } from '../../../shared/interfaces/paginated-data-response.interface';
+import { environment } from '../../../../environments/environment.dev';
+import { EndPoints } from '../../../shared/enums/end-point.enum';
+import { skipLoader } from '../../../utils/constants';
+import {
+  FlaggedComments,
+  FlaggedCommentView,
+  UpdateFlaggedCommentStatusRequest,
+} from '../../../pages/admin/content-moderation/interfaces/flagged-comments.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FlaggedCommentsService {
+  flaggedCommentUpdated$ = new BehaviorSubject<boolean>(false);
+
+  private readonly http = inject(HttpClient);
+
+  getFlaggedCommentsList(
+    request: PaginationRequest,
+  ): Observable<ApiResponse<PaginatedDataResponse<FlaggedComments>>> {
+    return this.http
+      .post<
+        ApiResponse<PaginatedDataResponse<FlaggedComments>>
+      >(`${environment.baseUrl}/${EndPoints.FlaggedContentList}`, request)
+      .pipe(map((res) => res)); // Extract `data` from wrapped ApiResponse
+  }
+
+  updateAction(payload: UpdateFlaggedCommentStatusRequest): Observable<ApiResponse<null>> {
+    return this.http.put<ApiResponse<null>>(
+      `${environment.baseUrl}/${EndPoints.ManageFlaggedCommentStatus}`,
+      payload,
+    );
+  }
+
+  getFlaggedCommentsPreviewById(id: number): Observable<ApiResponse<FlaggedCommentView>> {
+    return this.http.get<ApiResponse<FlaggedCommentView>>(
+      `${environment.baseUrl}/${EndPoints.FlaggedCommentsById}/${id}`,
+      {
+        headers: new HttpHeaders({
+          [skipLoader]: 'true',
+        }),
+      },
+    );
+  }
+
+  notifyFlaggedCommentUpdated() {
+    this.flaggedCommentUpdated$.next(true);
+  }
+}

--- a/src/app/shared/enums/content-moderation.enum.ts
+++ b/src/app/shared/enums/content-moderation.enum.ts
@@ -1,0 +1,20 @@
+export enum QuestionOrQuizIssueReportSeverity {
+  High = 1,
+  Low = 2,
+  Medium = 3,
+  UnderProcessing = 4,
+}
+
+export enum QuestionOrQuizIssueReportStatus {
+  Accepted = 1,
+  Ignore = 2,
+  Pending = 3,
+  UnderReview = 4,
+}
+
+export enum QuizRatingStatus {
+  Accepted = 1,
+  Ignore = 2,
+  Pending = 3,
+  UnderProcessing = 4,
+}

--- a/src/app/utils/tab-component-lazy-map.ts
+++ b/src/app/utils/tab-component-lazy-map.ts
@@ -133,8 +133,8 @@ export const tabLazyComponentMap: Record<string, () => Promise<Type<unknown>>> =
 
   flaggedComments: () =>
     import(
-      '../pages/layout/notification-center/components/notification-card/notification-card.component'
-    ).then((m) => m.NotificationCardComponent),
+      '../pages/admin/content-moderation/components/flagged-comments/flagged-comments.component'
+    ).then((m) => m.FlaggedCommentsComponent),
   reportedQuestions: () =>
     import(
       '../pages/admin/content-moderation/components/reported-questions/reported-questions.component'


### PR DESCRIPTION
--In this Pr I have add the Table listing of the flagged comments and logic to change status of the flagged comments that is to accept the flag or not in content moderation section


Preview
<img width="1524" height="685" alt="image" src="https://github.com/user-attachments/assets/2349afc5-270a-4272-b22e-5b080ea6eb7f" />
<img width="1544" height="648" alt="image" src="https://github.com/user-attachments/assets/83cf6ef6-2c81-45d3-8c03-dcfc05f058df" />
<img width="1544" height="648" alt="image" src="https://github.com/user-attachments/assets/dc2f9758-a8f4-48d6-a8fe-f5f6c250f12f" />
<img width="1526" height="425" alt="image" src="https://github.com/user-attachments/assets/86d89b3f-17fb-4dca-ab07-5034c5641f1e" />
<img width="1526" height="200" alt="image" src="https://github.com/user-attachments/assets/993e4ef7-59cb-49b4-8762-68e1ef04817a" />
